### PR TITLE
chore(auth): migrate admin password hashing to PBKDF2

### DIFF
--- a/API.md
+++ b/API.md
@@ -77,9 +77,10 @@
 - **使用位置**：`POST /admin/api` 的 `action: login`
 - **方式**：请求体字段 `username` / `password`（后端内部组装 `Basic base64(user:pass)` 进行校验）
 - **校验顺序**：
-  1. 若 `site_options.password` 已设置 → 与其 MD5 比对
-  2. 否则 → 与 `API_SECRET` 直接比对
-  3. 用户名：若 `site_options.username` 已设置则用之，否则使用 `API_USER_NAME` 环境变量，最终回退为 `admin`
+  1. 若 `site_options.password` 已设置为 PBKDF2 格式 → 按 `pbkdf2_sha256$iterations$salt$hash` 校验
+  2. 若 `site_options.password` 为旧版 32 位 MD5 → 按 MD5 兼容校验，成功后自动升级为 PBKDF2
+  3. 若 `site_options.password` 未设置或为空 → 与 `API_SECRET` 直接比对
+  4. 用户名：若 `site_options.username` 已设置则用之，否则使用 `API_USER_NAME` 环境变量，最终回退为 `admin`
 - **失败返回**：`401 { "error": "Invalid username or password", "code": 401 }`
 
 #### C. JWT Bearer（管理操作 → 后续管理请求）
@@ -871,7 +872,7 @@ Header：`X-Turnstile-Token: <token>`（当 `site_options.turnstile_enabled === 
     "turnstile_secret_key": "",
     "jwt_secret": "",
     "username": "admin",
-    "password": "<plain text, will be MD5-hashed before save>",
+    "password": "<plain text, will be PBKDF2-hashed before save>",
     "cloudflare_account_id": "",
     "cloudflare_token": "",
     "custom_ct": "gd-ct-dualstack.ip.zstaticcdn.com",
@@ -892,7 +893,7 @@ Header：`X-Turnstile-Token: <token>`（当 `site_options.turnstile_enabled === 
 
 **特殊处理**：
 
-- `password`：以**明文**传入；后端用 `crypto.subtle.digest('MD5', ...)` 计算后保存；如传空字符串则**不更新**密码
+- `password`：以**明文**传入；后端用 PBKDF2-HMAC-SHA-256（50,000 iterations、16 字节 salt、32 字节 hash）计算后保存为 `pbkdf2_sha256$50000$<salt hex>$<hash hex>`；如传空字符串则**不更新**密码；旧版 32 位 MD5 哈希仍可登录并会在成功登录后自动升级
 
 **Response 200**
 
@@ -1183,7 +1184,7 @@ Header：`X-Turnstile-Token: <token>`（当 `site_options.turnstile_enabled === 
   turnstile_secret_key: string,
   jwt_secret: string,            // 长度 ≥ 32 才会被用于签 JWT
   username: string,
-  password: string,              // MD5 哈希值
+  password: string,              // PBKDF2 哈希值；旧版 MD5 哈希会在成功登录后自动升级
   cloudflare_account_id: string,
   cloudflare_token: string,
   custom_ct: string,             // 电信测速节点域名
@@ -1402,4 +1403,3 @@ wscat -c "wss://status.example.com/api/ws?subscribe=9b2c4d3e-1a2b-4c5d-9e8f-7a6b
 ***
 
 > 文档同步：与源码 `src/index.js`、`src/handlers/{admin,dashboard,frontend,update}.js`、`src/durable/MetricsBroadcaster.js`、`src/utils/{auth,settings,errors,cors,cache,metrics,common}.js`、`src/database/{schema,updateDatabase}.js` 一一对应；后续修改任一文件时，请同步更新本文件。
-

--- a/src/handlers/admin.js
+++ b/src/handlers/admin.js
@@ -4,7 +4,7 @@ import { getAllServers } from '../utils/cache.js';
 import { clearServersListCache, clearServerDetailCache } from '../utils/cache.js';
 import { clearSiteSettingsCache, saveSiteOptions } from '../utils/settings.js';
 import { mergeMetricsIntoServer } from '../utils/metrics.js';
-import { verifyTurnstileToken, md5Hash } from '../utils/common.js';
+import { verifyTurnstileToken, hashPassword } from '../utils/common.js';
 import { AppError, createSuccessResponse, createBadRequestResponse, createUnauthorizedResponse, createErrorResponse } from '../utils/errors.js';
 import { addServerColumns } from '../database/updateDatabase.js';
 
@@ -164,10 +164,22 @@ export async function handleAdminAPI(request, env, sys) {
         }
       };
 
-      const isValid = await validateCredentials(mockRequest, env, sys);
+      const credentialResult = await validateCredentials(mockRequest, env, sys);
       
-      if (!isValid) {
+      if (!credentialResult.valid) {
         return createUnauthorizedResponse('Invalid username or password');
+      }
+
+      if (credentialResult.needsPasswordUpgrade) {
+        try {
+          const upgradedPasswordHash = await hashPassword(password);
+          await saveSiteOptions(env.DB, { password: upgradedPasswordHash });
+          if (sys) {
+            sys.password = upgradedPasswordHash;
+          }
+        } catch (e) {
+          console.error('Password hash upgrade failed:', e);
+        }
       }
 
       try {
@@ -311,7 +323,7 @@ export async function handleAdminAPI(request, env, sys) {
         if (settings[field] !== undefined) {
           if (field === 'password') {
             if (settings[field] && settings[field].length > 0) {
-              siteOptions[field] = await md5Hash(settings[field]);
+              siteOptions[field] = await hashPassword(settings[field]);
             }
           } else {
             siteOptions[field] = settings[field];

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,5 +1,5 @@
 const ALGORITHM = { name: 'HMAC', hash: 'SHA-256' };
-import { md5Hash } from '../utils/common.js';
+import { verifyPasswordHash } from '../utils/common.js';
 
 async function generateKeyFromSecret(secret) {
   const encoder = new TextEncoder();
@@ -111,7 +111,7 @@ export async function validateCredentials(request, env, sys) {
   try {
     const authHeader = request.headers.get('Authorization');
     if (!authHeader) {
-      return false;
+      return { valid: false, needsPasswordUpgrade: false };
     }
 
     const parts = authHeader.trim().split(/\s+/);
@@ -119,19 +119,19 @@ export async function validateCredentials(request, env, sys) {
     const encoded = parts[1];
 
     if (scheme !== 'Basic' || !encoded) {
-      return false;
+      return { valid: false, needsPasswordUpgrade: false };
     }
 
     let decoded;
     try {
       decoded = atob(encoded);
     } catch (e) {
-      return false;
+      return { valid: false, needsPasswordUpgrade: false };
     }
 
     const idx = decoded.indexOf(':');
     if (idx === -1) {
-      return false;
+      return { valid: false, needsPasswordUpgrade: false };
     }
 
     const username = decoded.slice(0, idx);
@@ -144,19 +144,27 @@ export async function validateCredentials(request, env, sys) {
         : 'admin';
 
     if (sys && sys.password && sys.password.length > 0) {
-      const hashedPassword = await md5Hash(password);
-      return username === validUsername && hashedPassword === sys.password;
+      if (username !== validUsername) {
+        return { valid: false, needsPasswordUpgrade: false };
+      }
+
+      const result = await verifyPasswordHash(password, sys.password);
+      return {
+        valid: result.valid,
+        needsPasswordUpgrade: result.needsRehash === true
+      };
     }
 
-    return (
+    const valid = (
       typeof env.API_SECRET === 'string' &&
       env.API_SECRET.length > 0 &&
       username === validUsername &&
       password === env.API_SECRET
     );
+    return { valid, needsPasswordUpgrade: false };
   } catch (e) {
     console.error('Credential validation error:', e);
-    return false;
+    return { valid: false, needsPasswordUpgrade: false };
   }
 }
 

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -35,7 +35,142 @@ export async function verifyTurnstileToken(token, secretKey) {
 }
 
 /**
- * 计算 MD5 哈希值
+ * 管理后台密码哈希参数
+ */
+export const PASSWORD_HASH_ALGORITHM = 'pbkdf2_sha256';
+export const PASSWORD_HASH_ITERATIONS = 50000;
+const PASSWORD_SALT_BYTES = 16;
+const PASSWORD_HASH_BYTES = 32;
+
+function bytesToHex(bytes) {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function hexToBytes(hex) {
+  if (!hex || hex.length % 2 !== 0 || !/^[a-f0-9]+$/i.test(hex)) {
+    return null;
+  }
+
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+function timingSafeEqualBytes(left, right) {
+  if (!(left instanceof Uint8Array) || !(right instanceof Uint8Array)) {
+    return false;
+  }
+
+  if (left.length === right.length && crypto.subtle && typeof crypto.subtle.timingSafeEqual === 'function') {
+    return crypto.subtle.timingSafeEqual(left, right);
+  }
+
+  let diff = left.length ^ right.length;
+  const maxLength = Math.max(left.length, right.length);
+  for (let i = 0; i < maxLength; i++) {
+    diff |= (left[i] || 0) ^ (right[i] || 0);
+  }
+  return diff === 0;
+}
+
+async function derivePbkdf2Hash(password, salt, iterations) {
+  const encoder = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(password),
+    'PBKDF2',
+    false,
+    ['deriveBits']
+  );
+
+  const bits = await crypto.subtle.deriveBits(
+    {
+      name: 'PBKDF2',
+      hash: 'SHA-256',
+      salt,
+      iterations
+    },
+    keyMaterial,
+    PASSWORD_HASH_BYTES * 8
+  );
+
+  return new Uint8Array(bits);
+}
+
+function parsePbkdf2Hash(storedHash) {
+  if (typeof storedHash !== 'string') {
+    return null;
+  }
+
+  const parts = storedHash.trim().split('$');
+  if (parts.length !== 4 || parts[0] !== PASSWORD_HASH_ALGORITHM) {
+    return null;
+  }
+
+  const iterations = Number(parts[1]);
+  const salt = hexToBytes(parts[2]);
+  const hash = hexToBytes(parts[3]);
+
+  if (
+    !Number.isInteger(iterations) ||
+    iterations <= 0 ||
+    !salt ||
+    salt.length !== PASSWORD_SALT_BYTES ||
+    !hash ||
+    hash.length !== PASSWORD_HASH_BYTES
+  ) {
+    return null;
+  }
+
+  return { iterations, salt, hash };
+}
+
+export function isLegacyMd5Hash(storedHash) {
+  return typeof storedHash === 'string' && /^[a-f0-9]{32}$/i.test(storedHash.trim());
+}
+
+export async function hashPassword(password) {
+  const salt = crypto.getRandomValues(new Uint8Array(PASSWORD_SALT_BYTES));
+  const hash = await derivePbkdf2Hash(password, salt, PASSWORD_HASH_ITERATIONS);
+  return `${PASSWORD_HASH_ALGORITHM}$${PASSWORD_HASH_ITERATIONS}$${bytesToHex(salt)}$${bytesToHex(hash)}`;
+}
+
+export async function verifyPasswordHash(password, storedHash) {
+  const parsed = parsePbkdf2Hash(storedHash);
+  if (parsed) {
+    const hash = await derivePbkdf2Hash(password, parsed.salt, parsed.iterations);
+    return {
+      valid: timingSafeEqualBytes(hash, parsed.hash),
+      needsRehash: false,
+      algorithm: PASSWORD_HASH_ALGORITHM
+    };
+  }
+
+  if (isLegacyMd5Hash(storedHash)) {
+    const hashedPassword = await md5Hash(password);
+    const actual = hexToBytes(hashedPassword);
+    const expected = hexToBytes(storedHash.trim().toLowerCase());
+    const valid = timingSafeEqualBytes(actual, expected);
+    return {
+      valid,
+      needsRehash: valid,
+      algorithm: 'md5'
+    };
+  }
+
+  return {
+    valid: false,
+    needsRehash: false,
+    algorithm: 'unknown'
+  };
+}
+
+/**
+ * 计算 MD5 哈希值，仅用于兼容旧版密码
  * @param {string} input - 输入字符串
  * @returns {Promise<string>} MD5 哈希值
  */
@@ -43,7 +178,5 @@ export async function md5Hash(input) {
   const encoder = new TextEncoder();
   const data = encoder.encode(input);
   const hash = await crypto.subtle.digest('MD5', data);
-  return Array.from(new Uint8Array(hash))
-    .map(b => b.toString(16).padStart(2, '0'))
-    .join('');
+  return bytesToHex(new Uint8Array(hash));
 }

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -40,6 +40,34 @@ function tryParseJSON(str) {
   }
 }
 
+function copyFields(target, source, fields) {
+  if (!source || typeof source !== 'object') return;
+  for (const field of fields) {
+    if (source[field] !== undefined) {
+      target[field] = source[field];
+    }
+  }
+}
+
+function hasMissingFields(source, fields) {
+  if (!source || typeof source !== 'object') return true;
+  return fields.some(field => source[field] === undefined);
+}
+
+async function loadLegacySettings(db, fields) {
+  const legacy = {};
+  const fieldSet = new Set(fields);
+  const { results } = await db.prepare('SELECT * FROM settings').all();
+  if (results && results.length > 0) {
+    results.forEach(r => {
+      if (fieldSet.has(r.key)) {
+        legacy[r.key] = r.value;
+      }
+    });
+  }
+  return legacy;
+}
+
 const SITE_SETTINGS_TTL = 60 * 1000;
 let cachedSiteSettings = null;
 let siteSettingsCacheExpiry = 0;
@@ -53,7 +81,7 @@ export async function loadSiteSettings(db) {
   debug('从数据库加载site settings');
 
   const result = { ...defaults };
-  let hasSite = false;
+  let siteOptions = null;
 
   try {
     const siteRow = await db.prepare(
@@ -62,25 +90,14 @@ export async function loadSiteSettings(db) {
     if (siteRow) {
       const parsed = tryParseJSON(siteRow.value);
       if (parsed) {
-        hasSite = true;
-        for (const field of SITE_FIELDS) {
-          if (parsed[field] !== undefined) {
-            result[field] = parsed[field];
-          }
-        }
+        siteOptions = parsed;
       }
     }
 
-    if (!hasSite) {
-      const { results } = await db.prepare('SELECT * FROM settings').all();
-      if (results && results.length > 0) {
-        results.forEach(r => {
-          if (SITE_FIELDS.includes(r.key)) {
-            result[r.key] = r.value;
-          }
-        });
-      }
+    if (hasMissingFields(siteOptions, SITE_FIELDS)) {
+      copyFields(result, await loadLegacySettings(db, SITE_FIELDS), SITE_FIELDS);
     }
+    copyFields(result, siteOptions, SITE_FIELDS);
   } catch (e) {
     console.error('加载站点设置失败:', e);
   }
@@ -97,8 +114,8 @@ export function clearSiteSettingsCache() {
 
 export async function loadSettings(db) {
   const result = { ...defaults };
-  let hasAppearance = false;
-  let hasSite = false;
+  let appearanceOptions = null;
+  let siteOptions = null;
 
   try {
     const appearanceRow = await db.prepare(
@@ -107,12 +124,7 @@ export async function loadSettings(db) {
     if (appearanceRow) {
       const parsed = tryParseJSON(appearanceRow.value);
       if (parsed) {
-        hasAppearance = true;
-        for (const field of APPEARANCE_FIELDS) {
-          if (parsed[field] !== undefined) {
-            result[field] = parsed[field];
-          }
-        }
+        appearanceOptions = parsed;
       }
     }
 
@@ -122,28 +134,24 @@ export async function loadSettings(db) {
     if (siteRow) {
       const parsed = tryParseJSON(siteRow.value);
       if (parsed) {
-        hasSite = true;
-        for (const field of SITE_FIELDS) {
-          if (parsed[field] !== undefined) {
-            result[field] = parsed[field];
-          }
-        }
+        siteOptions = parsed;
       }
     }
 
-    if (!hasAppearance || !hasSite) {
-      const { results } = await db.prepare('SELECT * FROM settings').all();
-      if (results && results.length > 0) {
-        results.forEach(r => {
-          if (!hasAppearance && APPEARANCE_FIELDS.includes(r.key)) {
-            result[r.key] = r.value;
-          }
-          if (!hasSite && SITE_FIELDS.includes(r.key)) {
-            result[r.key] = r.value;
-          }
-        });
+    const needsLegacyAppearance = hasMissingFields(appearanceOptions, APPEARANCE_FIELDS);
+    const needsLegacySite = hasMissingFields(siteOptions, SITE_FIELDS);
+    if (needsLegacyAppearance || needsLegacySite) {
+      const legacySettings = await loadLegacySettings(db, [...APPEARANCE_FIELDS, ...SITE_FIELDS]);
+      if (needsLegacyAppearance) {
+        copyFields(result, legacySettings, APPEARANCE_FIELDS);
+      }
+      if (needsLegacySite) {
+        copyFields(result, legacySettings, SITE_FIELDS);
       }
     }
+
+    copyFields(result, appearanceOptions, APPEARANCE_FIELDS);
+    copyFields(result, siteOptions, SITE_FIELDS);
   } catch (e) {
     console.error('加载设置失败:', e);
   }
@@ -159,8 +167,11 @@ export async function saveSiteOptions(db, updates) {
   const existingSiteOptions = siteRow && siteRow.value
     ? tryParseJSON(siteRow.value) || {}
     : {};
+  const legacySiteOptions = hasMissingFields(existingSiteOptions, SITE_FIELDS)
+    ? await loadLegacySettings(db, SITE_FIELDS)
+    : {};
   
-  const siteOptions = { ...existingSiteOptions, ...updates };
+  const siteOptions = { ...legacySiteOptions, ...existingSiteOptions, ...updates };
   
   await db.prepare(
     'INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value'


### PR DESCRIPTION
- 将管理后台密码存储从 MD5 迁移为 PBKDF2-HMAC-SHA-256
- 保留旧版 32 位 MD5 密码兼容登录
- 旧 MD5 密码登录成功、或者在管理面板中手动修改密码，都会自动升级为 PBKDF2 哈希
- 同步更新 API 文档中的密码存储与兼容说明