### PR TITLE
fix: Move WebSocket subscriptions into channel messages

### DIFF
--- a/API.md
+++ b/API.md
@@ -578,6 +578,8 @@ Sec-WebSocket-Version: 13
 | `subscribe=all` | 批量合并，每 5 秒一次 | `batchUpdate` | 减少消息数量，降低前端渲染压力 |
 | `subscribe=<serverId>` | 实时推送 | `update` | 单台服务器详情页，低延迟 |
 
+> `subscribe=all` 默认不推送任何服务器更新。客户端应先调用 `/api/servers` 获取当前可见服务器列表，再通过 WebSocket 通道发送 `subscribe` 消息，使用 `servers[].id` 作为过滤列表。该过滤是客户端订阅范围控制，不是服务端鉴权。
+
 **服务端 → 客户端消息**：
 
 1. 连接成功（Hello）
@@ -628,8 +630,22 @@ Sec-WebSocket-Version: 13
 **客户端 → 服务端消息**（可选）：
 
 ```json
+{ "type": "subscribe", "scope": "all", "ids": ["server-001", "server-002"] }
 { "type": "ping" }   // → 服务端回 { "type": "pong", "ts": ... }
 { "type": "pong" }   // 静默忽略
+```
+
+`subscribe` 消息用于更新当前 WebSocket 的订阅范围：
+
+- `scope`：可选，默认沿用 URL 中的 `subscribe`，通常为 `all`
+- `ids`：可选数组，来自 `/api/servers` 返回的 `servers[].id`；`subscribe=all` 时仅推送这些 ID 的更新。最多 500 个，每个 ID 长度 1-64，仅允许字母、数字、`.`、`_`、`:`、`-`
+
+若 `scope` 或 `ids` 格式非法，服务端会关闭 WebSocket 连接（close code `1008`）。
+
+服务端确认消息：
+
+```json
+{ "type": "subscribed", "ts": 1737638400000, "subscribed": "all", "count": 2 }
 ```
 
 **失败返回**：
@@ -640,7 +656,12 @@ Sec-WebSocket-Version: 13
 **前端使用示例（subscribe=all，批量推送）**：
 
 ```js
+const { servers } = await (await fetch('/api/servers')).json();
+const ids = servers.map(s => s.id);
 const ws = new WebSocket('wss://status.example.com/api/ws?subscribe=all');
+ws.onopen = () => {
+  ws.send(JSON.stringify({ type: 'subscribe', scope: 'all', ids }));
+};
 ws.onmessage = (ev) => {
   const msg = JSON.parse(ev.data);
   if (msg.type === 'batchUpdate') {
@@ -1201,6 +1222,8 @@ Header：`X-Turnstile-Token: <token>`（当 `site_options.turnstile_enabled === 
 | `type`   | 方向    | Payload                                            |
 | -------- | ----- | -------------------------------------------------- |
 | `hello`  | S → C | `{ ts: number, subscribed: string }`               |
+| `subscribe` | C → S | `{ scope: string, ids: string[] }`              |
+| `subscribed` | S → C | `{ ts: number, subscribed: string, count: number }` |
 | `ping`   | S → C | `{ ts: number }`                                   |
 | `pong`   | 双向    | `{ ts: number }`                                   |
 | `update` | S → C | `{ serverId: string, ts: number, data: <Server> }` |
@@ -1385,6 +1408,7 @@ curl https://status.example.com/__do/health
 ```bash
 # 订阅所有服务器
 wscat -c "wss://status.example.com/api/ws?subscribe=all"
+# 建连后发送：{"type":"subscribe","scope":"all","ids":["server-id"]}
 
 # 订阅指定服务器
 wscat -c "wss://status.example.com/api/ws?subscribe=9b2c4d3e-1a2b-4c5d-9e8f-7a6b5c4d3e2f"

--- a/src/durable/MetricsBroadcaster.js
+++ b/src/durable/MetricsBroadcaster.js
@@ -11,6 +11,11 @@
 // - 使用 DO WebSocket Hibernation API，闲置时休眠以节省资源。
 //   通过 setWebSocketAutoResponse 自动响应 ping，无需唤醒 DO。
 
+const MAX_SUBSCRIBE_IDS = 500;
+const MAX_SERVER_ID_LENGTH = 64;
+const SERVER_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+const WS_POLICY_VIOLATION = 1008;
+
 function parseAllowedOrigins(corsAllowedOrigins) {
   if (!corsAllowedOrigins || corsAllowedOrigins.trim() === '') {
     return [];
@@ -35,6 +40,57 @@ export class MetricsBroadcaster {
         JSON.stringify({ type: 'pong' })
       )
     );
+  }
+
+  _isValidServerId(id) {
+    return (
+      typeof id === 'string' &&
+      id.length > 0 &&
+      id.length <= MAX_SERVER_ID_LENGTH &&
+      SERVER_ID_PATTERN.test(id)
+    );
+  }
+
+  _isValidScope(scope) {
+    return scope === 'all' || this._isValidServerId(scope);
+  }
+
+  _normalizeServerIds(ids) {
+    if (ids === undefined) return { ok: true, ids: [] };
+    if (!Array.isArray(ids) || ids.length > MAX_SUBSCRIBE_IDS) {
+      return { ok: false, ids: [] };
+    }
+
+    const seen = new Set();
+    const normalized = [];
+    for (const id of ids) {
+      if (typeof id !== 'string') {
+        return { ok: false, ids: [] };
+      }
+
+      const value = id.trim();
+      if (!this._isValidServerId(value)) {
+        return { ok: false, ids: [] };
+      }
+
+      if (seen.has(value)) continue;
+      seen.add(value);
+      normalized.push(value);
+    }
+    return { ok: true, ids: normalized };
+  }
+
+  _closeInvalidSubscription(ws) {
+    try {
+      ws.close(WS_POLICY_VIOLATION, 'invalid subscription');
+    } catch (_) {}
+  }
+
+  _getSubscribeScope(msg, current) {
+    if (!Object.prototype.hasOwnProperty.call(msg, 'scope') || msg.scope === undefined) {
+      return current.scope || 'all';
+    }
+    return typeof msg.scope === 'string' ? msg.scope : null;
   }
 
   // 根据 scope 和 serverIds 判断是否需要接收某台服务器的更新
@@ -70,12 +126,9 @@ export class MetricsBroadcaster {
 
       const raw = url.searchParams.get('subscribe') || 'all';
       const scope = raw.trim().toLowerCase();
-
-      // 解析客户端传入的 server IDs 用于过滤
-      const idsParam = url.searchParams.get('ids') || '';
-      const serverIds = idsParam
-        ? idsParam.split(',').map(id => id.trim()).filter(id => id.length > 0)
-        : [];
+      if (!this._isValidScope(scope)) {
+        return new Response('Invalid subscription scope', { status: 400 });
+      }
 
       // @ts-ignore - Cloudflare Workers 运行时提供 WebSocketPair
       const pair = new WebSocketPair();
@@ -84,8 +137,8 @@ export class MetricsBroadcaster {
       // 使用 DO WebSocket Hibernation API 接管连接
       this.state.acceptWebSocket(server);
 
-      // 将订阅 scope 和 serverIds 附加到 WebSocket（休眠后仍保留）
-      server.serializeAttachment({ scope, serverIds });
+      // 将订阅 scope 和空 serverIds 附加到 WebSocket（休眠后仍保留）
+      server.serializeAttachment({ scope, serverIds: [] });
 
       // 立即发送 hello 让客户端确认连接成功
       try {
@@ -274,6 +327,38 @@ export class MetricsBroadcaster {
     // 保留处理扩展消息的入口
     try {
       const msg = JSON.parse(message || '{}');
+      if (msg && msg.type === 'subscribe') {
+        const current = ws.deserializeAttachment() || {};
+        const rawScope = this._getSubscribeScope(msg, current);
+        if (rawScope === null) {
+          this._closeInvalidSubscription(ws);
+          return;
+        }
+
+        const scope = rawScope.trim().toLowerCase();
+        if (!this._isValidScope(scope)) {
+          this._closeInvalidSubscription(ws);
+          return;
+        }
+
+        const normalizedServerIds = this._normalizeServerIds(msg.ids);
+        if (!normalizedServerIds.ok) {
+          this._closeInvalidSubscription(ws);
+          return;
+        }
+
+        const serverIds = normalizedServerIds.ids;
+        ws.serializeAttachment({ scope, serverIds });
+        try {
+          ws.send(JSON.stringify({
+            type: 'subscribed',
+            ts: Date.now(),
+            subscribed: scope,
+            count: serverIds.length
+          }));
+        } catch (_) {}
+        return;
+      }
       if (msg && msg.type === 'pong') return;
     } catch (_) {}
   }

--- a/src/frontend/utils/api.js
+++ b/src/frontend/utils/api.js
@@ -123,8 +123,7 @@ export const createLiveSocket = (subscribe, handlers = {}, apiIndex = 0, serverI
   const connect = () => {
     manualClose = false
     try {
-      const idsParam = serverIds && serverIds.length > 0 ? `&ids=${encodeURIComponent(serverIds.join(','))}` : ''
-      ws = new WebSocket(`${getWsBaseByIndex(apiIndex)}/api/ws?subscribe=${encodeURIComponent(scope)}${idsParam}`)
+      ws = new WebSocket(`${getWsBaseByIndex(apiIndex)}/api/ws?subscribe=${encodeURIComponent(scope)}`)
     } catch (e) {
       setStatus(false, 'WebSocket not supported')
       return
@@ -133,6 +132,13 @@ export const createLiveSocket = (subscribe, handlers = {}, apiIndex = 0, serverI
     ws.addEventListener('open', () => {
       reconnectDelay = TIME.RECONNECT_INITIAL_DELAY_MS
       reconnectAttempts = 0
+      try {
+        ws.send(JSON.stringify({
+          type: 'subscribe',
+          scope,
+          ids: Array.isArray(serverIds) ? serverIds : []
+        }))
+      } catch (_) {}
       setStatus(true, 'connected')
     })
 

--- a/theme-develop.md
+++ b/theme-develop.md
@@ -300,7 +300,7 @@ const { columns, rows } = await res.json();
 **Request**
 
 ```
-GET /api/ws?subscribe=<all|serverId>&ids=<id1,id2,...>
+GET /api/ws?subscribe=<all|serverId>
 Headers: Upgrade: websocket, Connection: Upgrade
 ```
 
@@ -309,23 +309,26 @@ Headers: Upgrade: websocket, Connection: Upgrade
 | 参数 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- |
 | `subscribe` | 否 | `all` | `all` 订阅所有服务器，`<serverId>` 只订阅指定服务器 |
-| `ids` | **是**（`subscribe=all` 时） | （空） | 逗号分隔的服务器 ID 列表，仅 `subscribe=all` 时生效。传入后只接收列表中服务器的更新。未传入时不返回任何更新 |
 
 **过滤机制**：
 
-- `subscribe=all` + 传入 `ids`：仅接收 ID 在列表中的服务器更新
-- `subscribe=all` + 未传 `ids`：**不返回任何更新**
-- `subscribe=<serverId>`：始终只接收该服务器更新，`ids` 参数无效
+- `subscribe=all` + 通道内发送 `subscribe` 消息：仅接收 `ids` 列表中的服务器更新
+- `subscribe=all` + 未发送 `subscribe` 消息：**不返回任何更新**
+- `subscribe=<serverId>`：始终只接收该服务器更新，不需要发送 `ids`
+- `ids` 最多 500 个，每个 ID 长度 1-64，仅允许字母、数字、`.`、`_`、`:`、`-`
+- `scope` 或 `ids` 格式非法时服务端会关闭 WebSocket 连接（close code `1008`）
+- `ids` 是客户端订阅过滤，不是服务端鉴权
 
 **多 apiBase 注意事项**：
 
-当配置了多个 `apiBase` 时，前端会为每个 apiBase 创建独立的 WebSocket 连接。每个连接的 `ids` 参数应只包含该 apiBase 返回的服务器 ID，而非全部服务器 ID。每个 Worker/DO 只知道自己的服务器，传入不属于它的 ID 不会产生任何效果。
+当配置了多个 `apiBase` 时，前端会为每个 apiBase 创建独立的 WebSocket 连接。每个连接发送的 `ids` 应只包含该 apiBase 返回的服务器 ID，而非全部服务器 ID。每个 Worker/DO 只知道自己的服务器，传入不属于它的 ID 不会产生任何效果。
 
 **推荐流程**：
 
 1. 调用 `GET /api/servers` 获取服务器列表（已按登录状态过滤隐藏服务器）
 2. 提取返回的 `servers[].id` 数组
-3. 连接 WebSocket 时将 ID 列表传入 `ids` 参数：`?subscribe=all&ids=id1,id2,id3`
+3. 连接 WebSocket：`?subscribe=all`
+4. 建连后通过 WebSocket 通道发送 `{ type: "subscribe", scope: "all", ids }`
 
 **推送策略**：
 
@@ -339,6 +342,8 @@ Headers: Upgrade: websocket, Connection: Upgrade
 | 类型 | 方向 | 数据结构 |
 | --- | --- | --- |
 | `hello` | S → C | `{ type: "hello", ts: number, subscribed: string }` |
+| `subscribe` | C → S | `{ type: "subscribe", scope: string, ids: string[] }` |
+| `subscribed` | S → C | `{ type: "subscribed", ts: number, subscribed: string, count: number }` |
 | `ping` | C → S | `{ type: "ping", ts: number }` |
 | `pong` | 双向 | `{ type: "pong", ts: number }` |
 | `update` | S → C | `{ type: "update", serverId: string, ts: number, data: Server }` |
@@ -351,10 +356,11 @@ Headers: Upgrade: websocket, Connection: Upgrade
 const { servers } = await (await fetch('/api/servers')).json();
 const ids = servers.map(s => s.id);
 
-// 2. 连接 WebSocket，只接收这些服务器的更新
-const ws = new WebSocket(
-  `wss://status.example.com/api/ws?subscribe=all&ids=${encodeURIComponent(ids.join(','))}`
-);
+// 2. 连接 WebSocket，并通过通道消息提交订阅 ID 列表
+const ws = new WebSocket('wss://status.example.com/api/ws?subscribe=all');
+ws.onopen = () => {
+  ws.send(JSON.stringify({ type: 'subscribe', scope: 'all', ids }));
+};
 ws.onmessage = (ev) => {
   const msg = JSON.parse(ev.data);
   if (msg.type === 'batchUpdate') {
@@ -506,12 +512,14 @@ interface Settings {
 }
 
 interface WsMessage {
-  type: 'hello' | 'ping' | 'pong' | 'update' | 'batchUpdate';
+  type: 'hello' | 'subscribe' | 'subscribed' | 'ping' | 'pong' | 'update' | 'batchUpdate';
   ts?: number;
   subscribed?: string;
+  scope?: string;
+  ids?: string[];
+  count?: number;
   serverId?: string;
   data?: Server;
   updates?: Array<{ serverId: string; ts: number; data: Server }>;
 }
 ```
-


### PR DESCRIPTION
- 将 `subscribe=all` 的服务器 ID 过滤从 URL `ids` 参数迁移到 WebSocket 通道内的 `subscribe` 消息
- 前端连接ws成功后发送 `{ type: "subscribe", scope, ids }`，支持重连后恢复订阅范围
- DO默认不再向 `subscribe=all` 连接推送任何服务器更新，直到收到订阅 ID 列表
- 更新 API 和主题开发文档中的 WebSocket 订阅协议、示例和限制说明