### PR TITLE
refactor: 重构历史数据查询与前端展示逻辑

### DIFF
--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -189,27 +189,11 @@ export async function getMetricsHistory(db, serverId, hours, columns, server = n
     return cached.data;
   }
   
-  let queryHours = hours;
-  let intervalMs;
-  
-  if (hours > 168) {
-    queryHours = 168;
-    intervalMs = 80 * 60 * 1000;
-  } else if (hours >= 96) {
-    intervalMs = 60 * 60 * 1000;
-  } else if (hours >= 48) {
-    intervalMs = 40 * 60 * 1000;
-  } else if (hours >= 24) {
-    intervalMs = 15 * 60 * 1000;
-  } else if (hours >= 12) {
-    intervalMs = 10 * 60 * 1000;
-  } else if (hours >= 6) {
-    intervalMs = 5 * 60 * 1000;
-  } else if (hours > 1) {
-    intervalMs = 1 * 60 * 1000;
-  } else {
-    intervalMs = 10 * 1000;
-  }
+  // 最多返回80个数据点,前端需要配合这个计算断点阈值
+  const queryHours = Math.min(hours, 168);
+  const MAX_POINTS = 80;
+  const totalMs = queryHours * 60 * 60 * 1000;
+  const intervalMs = Math.max(10_000, Math.ceil(totalMs / MAX_POINTS));
 
   const cutoff = now - queryHours * 60 * 60 * 1000;
   const historyInfo = await getServerHistoryInfo(db, serverId, server);
@@ -299,10 +283,10 @@ export async function getMetricsHistory(db, serverId, hours, columns, server = n
   }));
 
   result.sort((a, b) => a.timestamp - b.timestamp);
-  
+
   setMetricsHistoryCache(serverId, hours, columns, result);
 
-  debug(`[History] FINAL: ${result.length}`);
+  debug(`[History] FINAL: ${result.length}, interval: ${intervalMs}ms`);
 
   return result;
 }

--- a/src/frontend/utils/api.js
+++ b/src/frontend/utils/api.js
@@ -352,7 +352,7 @@ export const fetchAllHistory = async (id, hours, apiIndex = 0) => {
     error.message = result.message || result.error
     throw error
   }
-  return result.data
+  return Array.isArray(result.data) ? result.data : []
 }
 
 export const adminApi = async (data, apiIndex = 0) => {

--- a/src/frontend/utils/constants.js
+++ b/src/frontend/utils/constants.js
@@ -16,17 +16,6 @@ export const CHART = {
   MAX_TICKS_HOUR: 12
 }
 
-// 历史图表的前端换行阈值。
-// 每个值均为该范围对应的后端采样间隔乘以该范围的容差倍数，以便各范围可独立调优。
-export const HISTORY_SAMPLE_INTERVAL = {
-  BELOW_12_HOURS: 5 * 60 * 1000 * 1.1,
-  FROM_12_HOURS: 10 * 60 * 1000 * 1.1,
-  FROM_24_HOURS: 15 * 60 * 1000 * 1.1,
-  FROM_48_HOURS: 40 * 60 * 1000 * 1.1,
-  FROM_96_HOURS: 60 * 60 * 1000 * 1.1,
-  OVER_168_HOURS: 80 * 60 * 1000 * 1.1
-}
-
 export const PING = {
   GOOD_THRESHOLD: 100,
   WARNING_THRESHOLD: 200
@@ -57,7 +46,6 @@ export const COLORS = {
 export default {
   TIME,
   CHART,
-  HISTORY_SAMPLE_INTERVAL,
   PING,
   STORAGE,
   STATUS,

--- a/src/frontend/views/Admin.vue
+++ b/src/frontend/views/Admin.vue
@@ -526,7 +526,7 @@
       <div id="editModal" class="modal-overlay" :class="{ active: showEditModal }">
         <div class="modal-dialog">
           <div class="modal-header">
-            <div class="modal-title">$ vim /etc/server.conf</div>
+            <div class="modal-title">{{ currentServerName }}</div>
             <button class="modal-close" @click="closeEditModal">✕</button>
           </div>
           <input type="hidden" v-model="editForm.id">
@@ -625,9 +625,9 @@
             </div>
           </div>
 
-          <div class="modal-footer">
-            <button @click="closeEditModal" class="btn">{{ trans.cancel }}</button>
+          <div class="modal-footer flex-justify-between">
             <button @click="saveEdit" class="btn btn-primary">{{ trans.save }}</button>
+            <button @click="closeEditModal" class="btn">{{ trans.cancel }}</button>
           </div>
         </div>
       </div>
@@ -635,7 +635,7 @@
       <div id="deleteModal" class="modal-overlay" :class="{ active: showDeleteModal }">
         <div class="modal-dialog">
           <div class="modal-header">
-            <div class="modal-title">$ rm -rf /etc/server.conf</div>
+            <div class="modal-title">{{ currentServerName }}</div>
             <button class="modal-close" @click="closeDeleteModal">✕</button>
           </div>
           <input type="hidden" v-model="deleteServerId">
@@ -672,7 +672,7 @@
       <div id="copyModal" class="modal-overlay" :class="{ active: showCopyModal }">
         <div class="modal-dialog">
           <div class="modal-header">
-            <div class="modal-title">bash -s install</div>
+            <div class="modal-title">{{ currentServerName }}</div>
             <button class="modal-close" @click="closeCopyModal">✕</button>
           </div>
 
@@ -756,9 +756,9 @@
             </div>
           </div>
 
-          <div class="modal-footer flex-justify-end">
+          <div class="modal-footer flex-justify-between">
             <button @click="copyCustomCmd" class="btn btn-primary">{{ copiedCmd ? '✅ ' + trans.copied : '📋 ' + trans.copy }}</button>
-            <button @click="closeCopyModal" class="btn">{{ trans.close }}</button>
+            <button @click="closeCopyModal" class="btn">{{ trans.cancel }}</button>
           </div>
         </div>
       </div>
@@ -894,7 +894,8 @@
             {{ getMessage(d1UsageResult.error) }}
           </div>
 
-          <div class="modal-footer flex-justify-end">
+          <div class="modal-footer flex-justify-between">
+            <div></div>
             <button @click="d1UsageResult = null" class="btn">{{ trans.close }}</button>
           </div>
         </div>
@@ -914,7 +915,8 @@
             </div>
           </div>
 
-          <div class="modal-footer flex-justify-end">
+          <div class="modal-footer flex-justify-between">
+            <div></div>
             <button @click="validationError = null" class="btn">{{ trans.close }}</button>
           </div>
         </div>
@@ -941,8 +943,27 @@
             </div>
           </div>
 
-          <div class="modal-footer flex-justify-end">
+          <div class="modal-footer flex-justify-between">
+            <div></div>
             <button @click="saveResult = null" class="btn">{{ trans.close }}</button>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="alertMessage" class="modal-overlay active">
+        <div class="modal-dialog">
+          <div class="modal-header">
+            <div class="modal-title">$ alert</div>
+            <button class="modal-close" @click="alertMessage = null">✕</button>
+          </div>
+
+          <div class="mb-4">
+            <p class="text-secondary text-sm">{{ alertMessage }}</p>
+          </div>
+
+          <div class="modal-footer flex-justify-between">
+            <div></div>
+            <button @click="alertMessage = null" class="btn">{{ trans.close }}</button>
           </div>
         </div>
       </div>
@@ -1094,6 +1115,7 @@ const dbResult = ref(null)
 const d1UsageLoading = ref(false)
 const d1UsageResult = ref(null)
 const validationError = ref(null)
+const alertMessage = ref(null)
 
 const testNotificationLoading = ref(false)
 
@@ -1101,6 +1123,7 @@ const saveResult = ref(null)
 
 const showCopyModal = ref(false)
 const copyServerId = ref('')
+const currentServerName = ref('')
 const targetOs = ref('linux')
 const collectInterval = ref(0)
 const reportInterval = ref(60)
@@ -1539,6 +1562,7 @@ const getUninstallCommand = () => {
 const copyCmd = (serverId) => {
   const server = servers.value.find(s => s.id === serverId)
   copyServerId.value = serverId
+  currentServerName.value = server?.name || ''
   targetOs.value = 'linux'
   collectInterval.value = server?.collect_interval ?? 0
   reportInterval.value = server?.report_interval || 60
@@ -1651,6 +1675,7 @@ const openEditModal = (server) => {
     ping_mode: server.ping_mode || 'http',
     is_hidden: server.is_hidden === '1'
   }
+  currentServerName.value = server.name || ''
   showEditModal.value = true
 }
 
@@ -1692,6 +1717,8 @@ const saveEdit = async () => {
 
   const openDeleteModal = (id) => {
     deleteServerId.value = id
+    const server = servers.value.find(s => s.id === id)
+    currentServerName.value = server?.name || ''
     showDeleteModal.value = true
   }
 
@@ -1715,7 +1742,10 @@ const saveEdit = async () => {
   }
 
   const batchDelete = async () => {
-    if (selectedServers.value.length === 0) return alert(trans.value.selectServers)
+    if (selectedServers.value.length === 0) {
+      alertMessage.value = trans.value.selectServers
+      return
+    }
     if (!confirm(trans.value.confirmDeleteServers + selectedServers.value.length + trans.value.irreversible)) return
 
     try {
@@ -1789,7 +1819,8 @@ const getStatusText = (server) => {
     const file = e.target.files[0]
     if (!file) return
     if (file.size > 800 * 1024) {
-      alert(trans.value.imageSizeWarning)
+      alertMessage.value = trans.value.imageSizeWarning
+      return
     }
     const reader = new FileReader()
     reader.onload = function(event) {
@@ -1869,12 +1900,12 @@ const sendTestNotification = async () => {
       tg_chat_id: settings.value.tg_chat_id
     })
     if (!result.error) {
-      alert(getMessage(result.data.message) || trans.value.testNotificationSent)
+      alertMessage.value = getMessage(result.data.message) || trans.value.testNotificationSent
     } else {
-      alert(getMessage(result.error) || trans.value.testNotificationFailed)
+      alertMessage.value = getMessage(result.error) || trans.value.testNotificationFailed
     }
   } catch (e) {
-    alert(trans.value.testNotificationFailed + ': ' + e.message)
+    alertMessage.value = trans.value.testNotificationFailed + ': ' + e.message
   } finally {
     testNotificationLoading.value = false
   }

--- a/src/frontend/views/ServerDetail.vue
+++ b/src/frontend/views/ServerDetail.vue
@@ -273,9 +273,9 @@
         <div class="modal-body-content">
           <p class="modal-body-text">{{ trans.loginRequired }}</p>
         </div>
-        <div class="modal-footer">
-          <button @click="showLoginModal = false" class="btn modal-btn-full">{{ trans.cancel }}</button>
-          <button @click="goToLogin" class="btn btn-blue modal-btn-full">{{ trans.login }}</button>
+        <div class="modal-footer flex-justify-between">
+          <button @click="goToLogin" class="btn btn-primary">{{ trans.login }}</button>
+          <button @click="showLoginModal = false" class="btn">{{ trans.cancel }}</button>
         </div>
       </div>
     </div>
@@ -292,7 +292,7 @@ import { hasMultipleApiBases } from '../utils/config.js'
 import Chart from 'chart.js/auto'
 import 'chartjs-adapter-date-fns'
 import { t, currentLang, useTranslation } from '../utils/i18n'
-import { CHART, HISTORY_SAMPLE_INTERVAL } from '../utils/constants'
+import { CHART } from '../utils/constants'
 import { formatDateTime } from '../utils/time.js'
 import useTheme from '../composables/useTheme'
 
@@ -642,20 +642,21 @@ const updateChartsTheme = (theme) => {
   })
 }
 
+// ≤1h: 5分钟阈值; >1h: 总时长/80 * 1.1
 const getHistoryGapBreakMs = (hours = currentHours.value) => {
-  if (hours > 168) return HISTORY_SAMPLE_INTERVAL.OVER_168_HOURS
-  if (hours >= 96) return HISTORY_SAMPLE_INTERVAL.FROM_96_HOURS
-  if (hours >= 48) return HISTORY_SAMPLE_INTERVAL.FROM_48_HOURS
-  if (hours >= 24) return HISTORY_SAMPLE_INTERVAL.FROM_24_HOURS
-  if (hours >= 12) return HISTORY_SAMPLE_INTERVAL.FROM_12_HOURS
-  return HISTORY_SAMPLE_INTERVAL.BELOW_12_HOURS
+  if (hours <= 1) return 5 * 60 * 1000
+  return Math.ceil(hours * 60 * 60 * 1000 / 80) * 1.1
 }
 
 const shouldBreakGap = (prevPoint, nextPoint) => {
   if (!prevPoint || !nextPoint) return false
   const prevTime = Number(prevPoint.x)
   const nextTime = Number(nextPoint.x)
-  return Number.isFinite(prevTime) && Number.isFinite(nextTime) && nextTime - prevTime > getHistoryGapBreakMs()
+  if (!Number.isFinite(prevTime) || !Number.isFinite(nextTime)) return false
+  const gap = nextTime - prevTime
+  const breakThreshold = getHistoryGapBreakMs()
+  if (breakThreshold < 5 * 60 * 1000) return false
+  return gap > breakThreshold * 2
 }
 
 const applyGapBreak = (data) => {
@@ -779,8 +780,7 @@ const updateLoadChart = (chart, dataPoints) => {
 
 const loadAllHistory = async (hours) => {
   try {
-    const res = await fetchAllHistory(serverId, hours, apiIndex.value)
-    const allData = Array.isArray(res) ? res : []
+    const allData = await fetchAllHistory(serverId, hours, apiIndex.value)
 
     if (allData.length > 0) {
       hasLossHistoryData.value = allData.some(item => ['loss_ct', 'loss_cu', 'loss_cm', 'loss_bd'].some(key => isLossValid(item[key])))

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -19,6 +19,8 @@ let latestAllCacheTime = 0;
 
 const metricsHistoryCache = new Map();
 
+const serverDetailCache = new Map();
+
 export function getCacheDuration(hours) {
   if (hours >= 120) {
     return 10 * 60 * 1000;
@@ -60,12 +62,50 @@ export async function getAllServers(db, includeHidden = true) {
 
 export function clearServersListCache() {
   serversListCache = null;
+  serverDetailCache.clear();
+}
+
+export function clearServerDetailCache() {
+  serverDetailCache.clear();
 }
 
 export async function getServerDetail(db, id, includeHidden = false) {
-  const servers = await getAllServers(db, includeHidden);
-  const server = servers.find(item => item.id === id);
-  return server ? { ...server } : null;
+  const now = Date.now();
+  const cached = serverDetailCache.get(id);
+  
+  if (cached) {
+    if (now - cached.time < SERVERS_LIST_TTL) {
+      debug('服务器详情缓存命中');
+      const server = cached.data;
+      
+      if (!server) {
+        return null;
+      }
+      
+      if (!includeHidden && (server.is_hidden === 1 || server.is_hidden === '1')) {
+        return null;
+      }
+      
+      return { ...server };
+    }
+    
+    serverDetailCache.delete(id);
+  }
+  
+  const server = await db.prepare('SELECT * FROM servers WHERE id = ?').bind(id).first();
+
+  serverDetailCache.set(id, { data: server, time: now });
+  debug('服务器详情缓存更新');
+  
+  if (!server) {
+    return null;
+  }
+  
+  if (!includeHidden && (server.is_hidden === 1 || server.is_hidden === '1')) {
+    return null;
+  }
+  
+  return { ...server };
 }
 
 export async function checkServerExists(db, id) {


### PR DESCRIPTION
1.  简化后端历史数据采样间隔计算逻辑，统一按80个数据点自动计算间隔
2.  删除废弃的HISTORY_SAMPLE_INTERVAL常量
3.  优化前端图表断点判断逻辑，统一计算阈值
4.  新增服务器详情缓存机制并清理缓存函数
5.  修复API返回非数组时的类型错误
6.  优化Admin页面弹窗样式与标题，新增统一弹窗提示