### PR TITLE
fix: remove invalid script_name from Durable Object binding in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -25,7 +25,7 @@ database_name = "server-monitor-db"
 [[durable_objects.bindings]]
 name = "METRICS_BROADCASTER"
 class_name = "MetricsBroadcaster"
-script_name = "cf-server-monitor"
+
 
 [[migrations]]
 tag = "v1"


### PR DESCRIPTION
Cloudflare Workers 部署时出现以下错误：

Cannot create binding for class in script 'cf-server-monitor' that does not exist. [code: 10061]

原因是 wrangler.toml 中 Durable Object 配置包含：

script_name = "cf-server-monitor"

该字段会让 Cloudflare 将 MetricsBroadcaster Durable Object 绑定到另一个名为 cf-server-monitor 的 Worker 脚本中查找，而当前项目的 Durable Object 类实际定义在当前 Worker 入口文件 src/index.js 中。

项目已经通过：

export class MetricsBroadcaster extends _MetricsBroadcaster {}

将 Durable Object 类导出到 Worker 入口，因此不需要 script_name 配置。

修改后：

[[durable_objects.bindings]]
name = "METRICS_BROADCASTER"
class_name = "MetricsBroadcaster"

删除 script_name 后，Cloudflare Wrangler 可以正确识别并创建 Durable Object binding，部署恢复正常。

该修改不会影响已有功能，仅修复 Cloudflare 部署兼容性问题。