### PR TITLE
feat(metrics): 缓存并连续回放最新批量上报数据

### DIFF
--- a/src/durable/MetricsBroadcaster.js
+++ b/src/durable/MetricsBroadcaster.js
@@ -15,6 +15,8 @@ const MAX_SUBSCRIBE_IDS = 500;
 const MAX_SERVER_ID_LENGTH = 64;
 const SERVER_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
 const WS_POLICY_VIOLATION = 1008;
+const LATEST_REPORT_TTL_MS = 5 * 60 * 1000;
+const MAX_LATEST_REPORT_SERVERS = 1000;
 
 function parseAllowedOrigins(corsAllowedOrigins) {
   if (!corsAllowedOrigins || corsAllowedOrigins.trim() === '') {
@@ -30,6 +32,8 @@ export class MetricsBroadcaster {
   constructor(state, env) {
     this.state = state;
     this.env = env;
+    // 仅用于新页面快速接上最近一包数据；DO 重启或休眠回收后允许自然丢失。
+    this.latestReportUpdates = new Map();
 
     // 自动响应 ping 心跳，DO 无需被唤醒
     // @ts-ignore - Cloudflare Workers 运行时提供 WebSocketRequestResponsePair
@@ -223,11 +227,42 @@ export class MetricsBroadcaster {
         });
       }
 
-      this._broadcastBatch(normalizedUpdates);
+      const reportTs = Date.now();
+      this._cacheLatestReportUpdates(normalizedUpdates, reportTs);
+      this._broadcastBatch(normalizedUpdates, reportTs);
 
       const count = this.state.getWebSockets().length;
       return new Response(JSON.stringify({ ok: true, count: normalizedUpdates.length, subscribers: count }), {
         headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    // Worker 内部读取每台服务器最近一次上报的完整样本包。
+    if (method === 'POST' && path === '/latest-report-updates') {
+      let body = null;
+      try {
+        body = await request.json();
+      } catch (_) {
+        return new Response(JSON.stringify({ error: 'invalid JSON' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      const normalizedServerIds = this._normalizeServerIds(body?.serverIds);
+      if (!normalizedServerIds.ok) {
+        return new Response(JSON.stringify({ error: 'invalid serverIds' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      const updates = this._getLatestReportUpdates(normalizedServerIds.ids);
+      return new Response(JSON.stringify({ updates }), {
+        headers: {
+          'Cache-Control': 'no-store',
+          'Content-Type': 'application/json'
+        }
       });
     }
 
@@ -249,7 +284,54 @@ export class MetricsBroadcaster {
       serverId,
       samples: [{ ts, data: payload }]
     }];
-    this._broadcastBatch(updates);
+    this._cacheLatestReportUpdates(updates, ts);
+    this._broadcastBatch(updates, ts);
+  }
+
+  _pruneLatestReportUpdates(now = Date.now()) {
+    for (const [serverId, update] of this.latestReportUpdates) {
+      if (!update || now - update.reportTs > LATEST_REPORT_TTL_MS) {
+        this.latestReportUpdates.delete(serverId);
+      }
+    }
+  }
+
+  _cacheLatestReportUpdates(updates, reportTs = Date.now()) {
+    this._pruneLatestReportUpdates(reportTs);
+
+    for (const update of updates) {
+      if (!update || !update.serverId || !Array.isArray(update.samples) || update.samples.length === 0) continue;
+      const serverId = String(update.serverId);
+      // delete + set 让 Map 的插入顺序同时代表最近更新时间，便于限制内存上限。
+      this.latestReportUpdates.delete(serverId);
+      this.latestReportUpdates.set(serverId, {
+        serverId,
+        reportTs,
+        samples: update.samples
+      });
+    }
+
+    while (this.latestReportUpdates.size > MAX_LATEST_REPORT_SERVERS) {
+      const oldestServerId = this.latestReportUpdates.keys().next().value;
+      if (oldestServerId === undefined) break;
+      this.latestReportUpdates.delete(oldestServerId);
+    }
+  }
+
+  _getLatestReportUpdates(serverIds) {
+    const now = Date.now();
+    this._pruneLatestReportUpdates(now);
+    const updates = [];
+    for (const serverId of serverIds) {
+      const update = this.latestReportUpdates.get(serverId);
+      if (update) {
+        updates.push({
+          ...update,
+          reportAgeMs: Math.max(0, now - update.reportTs)
+        });
+      }
+    }
+    return updates;
   }
 
   // WebSocket 收到消息（ping 已被自动响应拦截，不会到达此处）
@@ -276,8 +358,7 @@ export class MetricsBroadcaster {
     }).filter(Boolean);
   }
 
-  _broadcastBatch(updates) {
-    const ts = Date.now();
+  _broadcastBatch(updates, ts = Date.now()) {
     const websockets = this.state.getWebSockets();
 
     for (const ws of websockets) {

--- a/src/frontend/utils/api.js
+++ b/src/frontend/utils/api.js
@@ -246,6 +246,7 @@ export const fetchServersAll = async () => {
 
 const createEmptyMergedData = () => ({
   servers: [],
+  latestReportUpdates: [],
   stats: { total: 0, online: 0, offline: 0, globalNetRx: 0, globalNetTx: 0, globalSpeedIn: 0, globalSpeedOut: 0 },
   regionStats: {},
   sysConfig: {
@@ -267,6 +268,12 @@ const mergeSiteResult = (mergedData, { data, error, baseUrl }, multiSite, localT
 
   for (const server of rawServers) {
     mergedData.servers.push({ ...server, source: baseUrl })
+  }
+
+  const latestReportUpdates = Array.isArray(data.latestReportUpdates) ? data.latestReportUpdates : []
+  for (const update of latestReportUpdates) {
+    if (!update || !update.serverId || !Array.isArray(update.samples)) continue
+    mergedData.latestReportUpdates.push({ ...update, source: baseUrl })
   }
 
   if (data.stats) {

--- a/src/frontend/utils/playback.js
+++ b/src/frontend/utils/playback.js
@@ -1,0 +1,28 @@
+function toFiniteNumber(value, fallback = null) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+export function resolvePlaybackCursor(
+  firstSampleTs,
+  currentDisplayTs,
+  { replayCachedReport = false, reportAgeMs = 0 } = {}
+) {
+  const first = toFiniteNumber(firstSampleTs)
+  if (first === null) return null
+
+  if (replayCachedReport) {
+    const age = Math.max(0, toFiniteNumber(reportAgeMs, 0))
+    return first + age
+  }
+
+  const current = toFiniteNumber(currentDisplayTs)
+  return current === null ? first : Math.max(first, current)
+}
+
+export function getPlaybackElapsedMs(nowTs, previousTickTs, fallbackMs = 1000) {
+  const now = toFiniteNumber(nowTs)
+  const previous = toFiniteNumber(previousTickTs)
+  if (now === null || previous === null || now < previous) return Math.max(0, fallbackMs)
+  return now - previous
+}

--- a/src/frontend/views/Dashboard.vue
+++ b/src/frontend/views/Dashboard.vue
@@ -396,7 +396,7 @@ const toLiveSample = (serverId, data, timestamp, reportTs) => {
   }
 }
 
-const queueLiveSamples = (serverId, samples, reportTs) => {
+const queueLiveSamples = (serverId, samples, reportTs, { replayCachedReport = false, reportAgeMs = 0 } = {}) => {
   if (!serverId || !Array.isArray(samples) || samples.length === 0) return
 
   const normalized = samples
@@ -408,7 +408,9 @@ const queueLiveSamples = (serverId, samples, reportTs) => {
 
   const current = servers.value.find(s => s.id === serverId)
   const currentTs = getServerSampleTimestamp(current)
-  const incoming = normalized.filter(sample => !currentTs || sample.ts > currentTs)
+  const incoming = replayCachedReport
+    ? normalized
+    : normalized.filter(sample => !currentTs || sample.ts > currentTs)
   if (incoming.length === 0) return
 
   if (incoming.length === 1) {
@@ -427,19 +429,27 @@ const queueLiveSamples = (serverId, samples, reportTs) => {
     unique.push(sample)
   }
   playbackBuffers.set(serverId, unique.slice(-MAX_BUFFER_SAMPLES_PER_SERVER))
-  applyPlaybackSamplesForServer(serverId, firstTs)
+  const normalizedReportAgeMs = Number(reportAgeMs)
+  const elapsedMs = replayCachedReport && Number.isFinite(normalizedReportAgeMs)
+    ? Math.max(0, normalizedReportAgeMs)
+    : 0
+  const lastTs = unique[unique.length - 1].ts
+  const playbackStartTs = Math.min(firstTs + elapsedMs, lastTs)
+  applyPlaybackSamplesForServer(serverId, playbackStartTs)
 }
 
-const queueLiveMessage = (msg) => {
+const queueLiveMessage = (msg, { replayCachedReport = false } = {}) => {
   if (!msg || msg.type !== 'batchUpdate') return
 
-  const reportTs = normalizeMetricTimestamp(msg.ts, Date.now())
+  const messageReportTs = normalizeMetricTimestamp(msg.ts, Date.now())
 
   const updates = Array.isArray(msg.updates) ? msg.updates : []
 
   for (const update of updates) {
     if (!update || !update.serverId) continue
     const samples = Array.isArray(update.samples) ? update.samples : []
+    const reportTs = normalizeMetricTimestamp(update.reportTs ?? update.report_timestamp, messageReportTs)
+    const reportAgeMs = replayCachedReport ? update.reportAgeMs : 0
 
     const liveSamples = []
     for (const sample of samples) {
@@ -451,8 +461,14 @@ const queueLiveMessage = (msg) => {
         data
       })
     }
-    queueLiveSamples(update.serverId, liveSamples, reportTs)
+    queueLiveSamples(update.serverId, liveSamples, reportTs, { replayCachedReport, reportAgeMs })
   }
+}
+
+const replayLatestReportUpdates = (data) => {
+  const updates = Array.isArray(data?.latestReportUpdates) ? data.latestReportUpdates : []
+  if (updates.length === 0) return
+  queueLiveMessage({ type: 'batchUpdate', ts: Date.now(), updates }, { replayCachedReport: true })
 }
 
 const applyServerSample = (serverId, data, sampleTs, displayTs, reportTs = null) => {
@@ -583,13 +599,14 @@ const loadDashboardConfig = async () => {
 const refreshData = async () => {
   const bases = getApiBases()
   const isMultiSite = bases.length > 1
+  playbackBuffers.clear()
 
   if (isMultiSite) {
     sitesRemaining.value = bases.length
     hasCorsError.value = null
 
     try {
-      await fetchServersAllWithProgress((data) => {
+      const data = await fetchServersAllWithProgress((data) => {
         const rawServers = Array.isArray(data.servers)
           ? data.servers
           : Object.entries(data.latestMetricsMap || {}).map(([id, metrics]) => ({ id, ...metrics }))
@@ -611,6 +628,7 @@ const refreshData = async () => {
         drawMarkers()
         sitesRemaining.value = Math.max(0, sitesRemaining.value - 1)
       })
+      replayLatestReportUpdates(data)
     } catch (e) {
       console.log('[INFO] Multi-site refresh error:', e)
     }
@@ -629,6 +647,7 @@ const refreshData = async () => {
       : Object.entries(data.latestMetricsMap || {}).map(([id, metrics]) => ({ id, ...metrics }))
 
     servers.value = mergeServersIntoList(rawServers)
+    replayLatestReportUpdates(data)
     recomputeStats(now.value)
 
     sysConfig.value = {

--- a/src/frontend/views/Dashboard.vue
+++ b/src/frontend/views/Dashboard.vue
@@ -237,6 +237,7 @@ import { currentLang, useTranslation } from '../utils/i18n.js'
 import { TIME, DEFAULT_SITE_TITLE, STORAGE } from '../utils/constants'
 import { normalizeTimestamp as normalizeMetricTimestamp } from '../utils/time.js'
 import { normalizeDashboardView, normalizeDisplayMode, resolveDisplayMode } from '../utils/displayMode.js'
+import { getPlaybackElapsedMs, resolvePlaybackCursor } from '../utils/playback.js'
 
 const servers = ref([])
 const stats = ref({ total: '-', online: 0, offline: 0, globalNetRx: 0, globalNetTx: 0, globalSpeedIn: 0, globalSpeedOut: 0 })
@@ -408,19 +409,25 @@ const queueLiveSamples = (serverId, samples, reportTs, { replayCachedReport = fa
 
   const current = servers.value.find(s => s.id === serverId)
   const currentTs = getServerSampleTimestamp(current)
+  const currentDisplayTs = getServerDisplayTimestamp(current)
   const incoming = replayCachedReport
     ? normalized
     : normalized.filter(sample => !currentTs || sample.ts > currentTs)
   if (incoming.length === 0) return
 
+  const playbackStartTs = resolvePlaybackCursor(incoming[0].ts, currentDisplayTs, {
+    replayCachedReport,
+    reportAgeMs
+  })
+  if (playbackStartTs === null) return
+
   if (incoming.length === 1) {
     playbackBuffers.delete(serverId)
     const sample = incoming[0]
-    applyServerSample(serverId, sample.data, sample.ts, sample.ts, reportTs)
+    applyServerSample(serverId, sample.data, sample.ts, playbackStartTs, reportTs)
     return
   }
 
-  const firstTs = incoming[0].ts
   const unique = []
   const seen = new Set()
   for (const sample of incoming) {
@@ -429,12 +436,6 @@ const queueLiveSamples = (serverId, samples, reportTs, { replayCachedReport = fa
     unique.push(sample)
   }
   playbackBuffers.set(serverId, unique.slice(-MAX_BUFFER_SAMPLES_PER_SERVER))
-  const normalizedReportAgeMs = Number(reportAgeMs)
-  const elapsedMs = replayCachedReport && Number.isFinite(normalizedReportAgeMs)
-    ? Math.max(0, normalizedReportAgeMs)
-    : 0
-  const lastTs = unique[unique.length - 1].ts
-  const playbackStartTs = Math.min(firstTs + elapsedMs, lastTs)
   applyPlaybackSamplesForServer(serverId, playbackStartTs)
 }
 
@@ -522,7 +523,8 @@ const advanceServerClocks = () => {
     const reportTs = getServerReportTimestamp(server, null)
     const isOnline = reportTs && (currentTs - reportTs) < TIME.ONLINE_THRESHOLD_MS
     const currentDisplayTs = getServerDisplayTimestamp(server) || getServerSampleTimestamp(server) || reportTs
-    const nextDisplayTs = isOnline && currentDisplayTs ? currentDisplayTs + PLAYBACK_TICK_MS : currentDisplayTs
+    const elapsedMs = getPlaybackElapsedMs(currentTs, server.current_timestamp, PLAYBACK_TICK_MS)
+    const nextDisplayTs = isOnline && currentDisplayTs ? currentDisplayTs + elapsedMs : currentDisplayTs
     return withDisplayTiming(server, nextDisplayTs, currentTs)
   })
   applyPlaybackSamples()

--- a/src/handlers/dashboard.js
+++ b/src/handlers/dashboard.js
@@ -4,12 +4,41 @@ import { getAllServers, getServerDetail } from '../utils/cache.js';
 import { mergeMetricsIntoServer } from '../utils/metrics.js';
 import { createSuccessResponse, createBadRequestResponse, createNotFoundResponse } from '../utils/errors.js';
 
+const LATEST_REPORT_ID_CHUNK_SIZE = 500;
+
 function withoutPrivateServerFields(server) {
   const item = { ...server };
   delete item.bandwidth;
   delete item.note;
   delete item.auto_update;
   return item;
+}
+
+async function getLatestReportUpdates(env, serverIds) {
+  if (!env.METRICS_BROADCASTER || !Array.isArray(serverIds) || serverIds.length === 0) return [];
+
+  try {
+    const id = env.METRICS_BROADCASTER.idFromName('global');
+    const stub = env.METRICS_BROADCASTER.get(id);
+    const updates = [];
+
+    for (let offset = 0; offset < serverIds.length; offset += LATEST_REPORT_ID_CHUNK_SIZE) {
+      const chunk = serverIds.slice(offset, offset + LATEST_REPORT_ID_CHUNK_SIZE);
+      const response = await stub.fetch('http://internal/latest-report-updates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ serverIds: chunk })
+      });
+      if (!response.ok) continue;
+      const data = await response.json();
+      if (Array.isArray(data?.updates)) updates.push(...data.updates);
+    }
+
+    return updates;
+  } catch (e) {
+    console.warn('[Dashboard] Failed to read latest report updates:', e?.message || e);
+    return [];
+  }
 }
 
 export async function handleServerAPI(request, env, sys) {
@@ -45,7 +74,10 @@ export async function handleServersAPI(request, env, sys) {
   
   const results = (await getAllServers(env.DB, isLoggedIn)).map(withoutPrivateServerFields);
   
-  const latestMetricsMap = await getLatestMetricsForAllServers(env.DB);
+  const [latestMetricsMap, latestReportUpdates] = await Promise.all([
+    getLatestMetricsForAllServers(env.DB),
+    getLatestReportUpdates(env, results.map(server => server.id).filter(Boolean))
+  ]);
   
   const now = Date.now();
   let globalOnline = 0;
@@ -81,6 +113,7 @@ export async function handleServersAPI(request, env, sys) {
 
   const data = {
     servers: results,
+    latestReportUpdates,
     stats: {
       total: results.length,
       online: globalOnline,

--- a/src/handlers/dashboard.js
+++ b/src/handlers/dashboard.js
@@ -3,6 +3,11 @@ import { getLatestMetrics, getLatestMetricsForAllServers } from '../database/sch
 import { getAllServers, getServerDetail } from '../utils/cache.js';
 import { mergeMetricsIntoServer } from '../utils/metrics.js';
 import { createSuccessResponse, createBadRequestResponse, createNotFoundResponse } from '../utils/errors.js';
+import {
+  cacheLatestReportUpdate,
+  getLatestReportSampleTimestamp,
+  getWorkerLatestReportUpdates
+} from '../utils/latestReportCache.js';
 
 const LATEST_REPORT_ID_CHUNK_SIZE = 500;
 
@@ -14,7 +19,7 @@ function withoutPrivateServerFields(server) {
   return item;
 }
 
-async function getLatestReportUpdates(env, serverIds) {
+async function getDurableLatestReportUpdates(env, serverIds) {
   if (!env.METRICS_BROADCASTER || !Array.isArray(serverIds) || serverIds.length === 0) return [];
 
   try {
@@ -39,6 +44,31 @@ async function getLatestReportUpdates(env, serverIds) {
     console.warn('[Dashboard] Failed to read latest report updates:', e?.message || e);
     return [];
   }
+}
+
+function mergeLatestReportUpdates(serverIds, durableUpdates, workerUpdates) {
+  const merged = new Map();
+
+  for (const update of durableUpdates) {
+    if (!update?.serverId || !Array.isArray(update.samples)) continue;
+    merged.set(String(update.serverId), update);
+  }
+
+  // Worker 缓存后合并：样本更新时取更新的一包；同一包优先使用更准确的 Worker 接收时间。
+  for (const update of workerUpdates) {
+    if (!update?.serverId || !Array.isArray(update.samples)) continue;
+    const serverId = String(update.serverId);
+    const existing = merged.get(serverId);
+    if (!existing || getLatestReportSampleTimestamp(update) >= getLatestReportSampleTimestamp(existing)) {
+      merged.set(serverId, update);
+    }
+  }
+
+  const now = Date.now();
+  return serverIds.map(serverId => merged.get(String(serverId))).filter(Boolean).map(update => ({
+    ...update,
+    reportAgeMs: Math.max(0, now - Number(update.reportTs || now))
+  }));
 }
 
 export async function handleServerAPI(request, env, sys) {
@@ -74,10 +104,21 @@ export async function handleServersAPI(request, env, sys) {
   
   const results = (await getAllServers(env.DB, isLoggedIn)).map(withoutPrivateServerFields);
   
-  const [latestMetricsMap, latestReportUpdates] = await Promise.all([
+  const serverIds = results.map(server => server.id).filter(Boolean);
+  const [latestMetricsMap, durableLatestReportUpdates] = await Promise.all([
     getLatestMetricsForAllServers(env.DB),
-    getLatestReportUpdates(env, results.map(server => server.id).filter(Boolean))
+    getDurableLatestReportUpdates(env, serverIds)
   ]);
+
+  // DO 命中后反向预热当前 Worker isolate，降低随后 DO 休眠造成的空缓存概率。
+  for (const update of durableLatestReportUpdates) {
+    cacheLatestReportUpdate(update.serverId, update.samples, update.reportTs);
+  }
+  const latestReportUpdates = mergeLatestReportUpdates(
+    serverIds,
+    durableLatestReportUpdates,
+    getWorkerLatestReportUpdates(serverIds)
+  );
   
   const now = Date.now();
   let globalOnline = 0;

--- a/src/handlers/update.js
+++ b/src/handlers/update.js
@@ -4,6 +4,7 @@ import { mergeMetricsIntoServer } from '../utils/metrics.js';
 import { createErrorResponse, createUnauthorizedResponse, createNotFoundResponse, createBadRequestResponse } from '../utils/errors.js';
 import { ensureServerOptimization } from '../database/indexOptimization.js';
 import { AGENT_VERSION, loadSiteSettings } from '../utils/settings.js';
+import { cacheLatestReportUpdate } from '../utils/latestReportCache.js';
 import {
   AGENT_CONFIG_MD5_HEADER,
   AGENT_CONFIG_SCHEMA_HEADER,
@@ -241,6 +242,7 @@ export async function handleUpdate(request, env, ctx) {
     );
 
     const broadcastSamples = toBroadcastSamples(id, samples, regionCode, agentVersion);
+    cacheLatestReportUpdate(id, broadcastSamples, Date.now());
     // 加入批量队列，由后台定时任务统一推送到 DO
     queueBroadcastSamples(id, broadcastSamples);
     ctx.waitUntil(_ensureBatchFlush(env));

--- a/src/utils/latestReportCache.js
+++ b/src/utils/latestReportCache.js
@@ -1,0 +1,91 @@
+const LATEST_REPORT_TTL_MS = 5 * 60 * 1000;
+const MAX_LATEST_REPORT_SERVERS = 1000;
+
+// 普通 Worker isolate 内的尽力而为缓存；不同 isolate 之间不共享。
+const latestReportUpdates = new Map();
+
+function normalizeTimestamp(value, fallback = 0) {
+  const timestamp = Number(value);
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return fallback;
+  return timestamp < 10000000000 ? timestamp * 1000 : timestamp;
+}
+
+function getLatestSampleTimestamp(samples) {
+  if (!Array.isArray(samples)) return 0;
+  let latest = 0;
+  for (const sample of samples) {
+    if (!sample || typeof sample !== 'object') continue;
+    const data = sample.data || sample.payload || sample.metrics || {};
+    const timestamp = normalizeTimestamp(
+      sample.ts ?? sample.timestamp ?? data.sample_timestamp ?? data.last_updated ?? data.timestamp,
+      0
+    );
+    if (timestamp > latest) latest = timestamp;
+  }
+  return latest;
+}
+
+function pruneLatestReportUpdates(now = Date.now()) {
+  for (const [serverId, update] of latestReportUpdates) {
+    if (!update || now - update.reportTs > LATEST_REPORT_TTL_MS) {
+      latestReportUpdates.delete(serverId);
+    }
+  }
+}
+
+export function cacheLatestReportUpdate(serverId, samples, reportTs = Date.now()) {
+  if (!serverId || !Array.isArray(samples) || samples.length === 0) return;
+
+  const now = Date.now();
+  const normalizedReportTs = normalizeTimestamp(reportTs, now);
+  if (now - normalizedReportTs > LATEST_REPORT_TTL_MS) return;
+
+  pruneLatestReportUpdates(now);
+  const normalizedServerId = String(serverId);
+  const latestSampleTs = getLatestSampleTimestamp(samples);
+  const existing = latestReportUpdates.get(normalizedServerId);
+
+  if (existing) {
+    if (existing.latestSampleTs > latestSampleTs) return;
+    // 同一包从 DO 回填时保留更早的 Worker 接收时间，保证回放偏移准确。
+    if (existing.latestSampleTs === latestSampleTs) {
+      existing.reportTs = Math.min(existing.reportTs, normalizedReportTs);
+      return;
+    }
+  }
+
+  latestReportUpdates.delete(normalizedServerId);
+  latestReportUpdates.set(normalizedServerId, {
+    serverId: normalizedServerId,
+    reportTs: normalizedReportTs,
+    latestSampleTs,
+    samples
+  });
+
+  while (latestReportUpdates.size > MAX_LATEST_REPORT_SERVERS) {
+    const oldestServerId = latestReportUpdates.keys().next().value;
+    if (oldestServerId === undefined) break;
+    latestReportUpdates.delete(oldestServerId);
+  }
+}
+
+export function getWorkerLatestReportUpdates(serverIds, now = Date.now()) {
+  pruneLatestReportUpdates(now);
+  if (!Array.isArray(serverIds)) return [];
+
+  const updates = [];
+  for (const serverId of serverIds) {
+    const update = latestReportUpdates.get(String(serverId));
+    if (!update) continue;
+    const { latestSampleTs: _latestSampleTs, ...publicUpdate } = update;
+    updates.push({
+      ...publicUpdate,
+      reportAgeMs: Math.max(0, now - update.reportTs)
+    });
+  }
+  return updates;
+}
+
+export function getLatestReportSampleTimestamp(update) {
+  return getLatestSampleTimestamp(update?.samples);
+}


### PR DESCRIPTION
 ## 变更内容

  - 在 Durable Object 内存中缓存每台服务器最近一次完整上报包
  - 通过 `/api/servers` 的 `latestReportUpdates` 字段下发缓存样本
  - 增加普通 Worker isolate 内存备份，并与 DO 缓存按最新样本合并
  - DO 缓存命中后反向预热当前 Worker，降低缓存空数组概率
  - 页面首次打开时根据包龄选择对应样本，而非等待下一次上报
  - 使用单调播放游标，避免新批次到达时发生时间回跳
  - 根据真实 tick 间隔推进时间，兼容页面卡顿和浏览器定时器节流

  ## 缓存策略

  - 缓存有效期为 5 分钟
  - 最多缓存 1000 台服务器
  - 不使用 DO Storage，不增加 D1 或 DO 持久化写入
  - Worker 与 DO 内存同时失效时，自动回退到 D1 最新快照

  ## 验证

  - Worker 缓存新旧包覆盖测试通过
  - 60 秒上报及 5 秒 DO 延迟时间线模拟通过
  - 前端生产构建通过：`npm run build:frontend`
  - Wrangler 打包检查通过：`npx wrangler deploy --dry-run`
  - JavaScript 语法及 `git diff --check` 通过