### PR TITLE
feat(theme): 支持白名单远程主题代理

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:frontend": "node scripts/build.js",
     "build:github-page": "node scripts/build-github-page.js",
     "test:agent-config": "node test/agent-config.js",
+    "test:theme-proxy": "node test/theme-proxy.js",
     "preview": "vite preview"
   },
   "keywords": [

--- a/src/handlers/themeProxy.js
+++ b/src/handlers/themeProxy.js
@@ -1,0 +1,149 @@
+const THEME_URL_PARAM = 'theme-url';
+const ALLOWED_THEME_BASE_URLS = new Set([
+  'https://huilang-me.github.io/cf-server-monitor-theme-emerald'
+]);
+
+function getAllowedThemeBaseUrl(value) {
+  if (typeof value !== 'string' || value.trim() === '') return null;
+
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== 'https:' || url.username || url.password || url.search || url.hash) return null;
+    const pathname = url.pathname.replace(/\/+$/, '');
+    const normalized = `${url.origin}${pathname}`;
+    return ALLOWED_THEME_BASE_URLS.has(normalized) ? normalized : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function getThemeRequest(request) {
+  if (request.method !== 'GET') return null;
+
+  const requestUrl = new URL(request.url);
+  if (requestUrl.pathname === '/' && requestUrl.searchParams.has(THEME_URL_PARAM)) {
+    return {
+      baseUrl: getAllowedThemeBaseUrl(requestUrl.searchParams.get(THEME_URL_PARAM)),
+      hasThemeUrl: true,
+      isDocument: true,
+      requestUrl
+    };
+  }
+
+  if (!requestUrl.pathname.startsWith('/assets/')) return null;
+
+  const referer = request.headers.get('Referer');
+  if (!referer) return null;
+
+  try {
+    const refererUrl = new URL(referer);
+    if (refererUrl.origin !== requestUrl.origin || !refererUrl.searchParams.has(THEME_URL_PARAM)) return null;
+    return {
+      baseUrl: getAllowedThemeBaseUrl(refererUrl.searchParams.get(THEME_URL_PARAM)),
+      hasThemeUrl: true,
+      isDocument: false,
+      requestUrl
+    };
+  } catch (_) {
+    return null;
+  }
+}
+
+function buildUpstreamUrl(baseUrl, requestUrl, isDocument) {
+  if (isDocument) return new URL(`${baseUrl}/`);
+  const themeBaseUrl = new URL(`${baseUrl}/`);
+  const upstreamUrl = new URL(requestUrl.pathname.replace(/^\/+/, ''), themeBaseUrl);
+  const assetsPathPrefix = `${themeBaseUrl.pathname}assets/`;
+  if (upstreamUrl.origin !== themeBaseUrl.origin || !upstreamUrl.pathname.startsWith(assetsPathPrefix)) {
+    return null;
+  }
+  upstreamUrl.search = requestUrl.search;
+  return upstreamUrl;
+}
+
+function buildUpstreamHeaders(request) {
+  const headers = new Headers();
+  for (const name of ['Accept', 'Accept-Language', 'Range']) {
+    const value = request.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  return headers;
+}
+
+function buildResponseHeaders(upstreamHeaders, bodyWasRewritten = false) {
+  const headers = new Headers(upstreamHeaders);
+  headers.delete('Set-Cookie');
+  headers.set('Cache-Control', 'no-store');
+  if (bodyWasRewritten) {
+    headers.delete('Content-Encoding');
+    headers.delete('Content-Length');
+    headers.delete('ETag');
+    headers.delete('Last-Modified');
+  }
+  return headers;
+}
+
+export function removeApiBaseMeta(html) {
+  return String(html).replace(
+    /<meta\b(?=[^>]*\sname\s*=\s*(['"])apiBase\1)[^>]*>/gi,
+    ''
+  );
+}
+
+function createThemeProxyError(message, status) {
+  return new Response(message, {
+    status,
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Type': 'text/plain; charset=UTF-8'
+    }
+  });
+}
+
+export async function tryServeThemeProxy(request) {
+  const themeRequest = getThemeRequest(request);
+  if (!themeRequest) return null;
+  if (themeRequest.hasThemeUrl && !themeRequest.baseUrl) {
+    return createThemeProxyError('Theme URL is not allowed', 403);
+  }
+
+  const upstreamUrl = buildUpstreamUrl(
+    themeRequest.baseUrl,
+    themeRequest.requestUrl,
+    themeRequest.isDocument
+  );
+  if (!upstreamUrl) {
+    return createThemeProxyError('Theme asset path is not allowed', 403);
+  }
+
+  let upstreamResponse;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: 'GET',
+      headers: buildUpstreamHeaders(request),
+      redirect: 'manual'
+    });
+  } catch (_) {
+    return createThemeProxyError('Theme upstream is unavailable', 502);
+  }
+
+  if (upstreamResponse.status >= 300 && upstreamResponse.status < 400) {
+    return createThemeProxyError('Theme upstream redirect is not allowed', 502);
+  }
+
+  const contentType = upstreamResponse.headers.get('Content-Type') || '';
+  if (themeRequest.isDocument && contentType.toLowerCase().includes('text/html')) {
+    const html = removeApiBaseMeta(await upstreamResponse.text());
+    return new Response(html, {
+      status: upstreamResponse.status,
+      statusText: upstreamResponse.statusText,
+      headers: buildResponseHeaders(upstreamResponse.headers, true)
+    });
+  }
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers: buildResponseHeaders(upstreamResponse.headers)
+  });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { serveFrontend } from './handlers/frontend.js';
 import { handleUpdate, handleWebSocketUpgrade } from './handlers/update.js';
 import { handleServerAPI, handleServersAPI } from './handlers/dashboard.js';
 import { handleTheme } from './handlers/theme.js';
+import { tryServeThemeProxy } from './handlers/themeProxy.js';
 import { loadSettings, loadSiteSettings, loadAppearanceOptions, setDebug, debug, getCurrentVersion } from './utils/settings.js';
 import { checkAuth, simpleAuthResponse } from './middleware/auth.js';
 import { getServerDetail, getMetricsHistoryCache, setMetricsHistoryCache, getCacheDuration } from './utils/cache.js';
@@ -154,6 +155,11 @@ export default {
     
     if (method === 'OPTIONS') {
       return createOptionsResponse(request, corsAllowedOrigins);
+    }
+
+    const themeProxyResponse = await tryServeThemeProxy(request);
+    if (themeProxyResponse) {
+      return applyCors(themeProxyResponse, request, corsAllowedOrigins);
     }
 
     if (env.ASSETS && method === 'GET') {

--- a/test/theme-proxy.js
+++ b/test/theme-proxy.js
@@ -1,0 +1,104 @@
+import { tryServeThemeProxy } from '../src/handlers/themeProxy.js';
+
+const ALLOWED_THEME = 'https://huilang-me.github.io/cf-server-monitor-theme-emerald';
+const calls = [];
+const originalFetch = globalThis.fetch;
+let redirectNextFetch = false;
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+globalThis.fetch = async (input, init) => {
+  const url = String(input);
+  calls.push({ url, init });
+
+  if (redirectNextFetch) {
+    redirectNextFetch = false;
+    return new Response(null, {
+      status: 302,
+      headers: { Location: 'https://evil.example/theme' }
+    });
+  }
+
+  if (url.endsWith('/')) {
+    return new Response(`<!doctype html><html><head>
+      <meta name="viewport" content="width=device-width">
+      <meta name="apiBase" content="https://a.example,https://b.example"/>
+      <meta content="dynamic-value" data-test="true" name="APIBASE">
+    </head><body>theme</body></html>`, {
+      headers: {
+        'Content-Type': 'text/html; charset=UTF-8',
+        'Content-Length': '999',
+        'Content-Encoding': 'gzip',
+        'Set-Cookie': 'secret=1',
+        'ETag': 'abc'
+      }
+    });
+  }
+
+  return new Response('asset-body', {
+    headers: {
+      'Content-Type': 'application/javascript',
+      'Set-Cookie': 'secret=1'
+    }
+  });
+};
+
+try {
+  const rootResponse = await tryServeThemeProxy(new Request(
+    `https://monitor.example/?theme-url=${encodeURIComponent(ALLOWED_THEME)}`,
+    { headers: { Cookie: 'session=secret', Authorization: 'Bearer secret' } }
+  ));
+  const html = await rootResponse.text();
+
+  assert(rootResponse.status === 200, 'allowed theme should be proxied');
+  assert(!/<meta\b[^>]*\sname=["']apiBase["']/i.test(html), 'apiBase meta should be removed');
+  assert(/name="viewport"/.test(html), 'unrelated meta should remain');
+  assert(!rootResponse.headers.get('Content-Length'), 'rewritten content length should be removed');
+  assert(!rootResponse.headers.get('Content-Encoding'), 'rewritten content encoding should be removed');
+  assert(!rootResponse.headers.get('Set-Cookie'), 'upstream cookie should be removed');
+  assert(rootResponse.headers.get('Cache-Control') === 'no-store', 'proxy response should not be cached');
+  assert(calls[0].url === `${ALLOWED_THEME}/`, 'theme document target is incorrect');
+  assert(calls[0].init.redirect === 'manual', 'redirects must be handled manually');
+  assert(!calls[0].init.headers.has('Cookie'), 'cookie must not be forwarded');
+  assert(!calls[0].init.headers.has('Authorization'), 'authorization must not be forwarded');
+
+  const invalidResponse = await tryServeThemeProxy(new Request(
+    `https://monitor.example/?theme-url=${encodeURIComponent('https://evil.example/theme')}`
+  ));
+  assert(invalidResponse.status === 403, 'disallowed theme should be rejected');
+  assert(calls.length === 1, 'disallowed theme must not reach fetch');
+
+  redirectNextFetch = true;
+  const redirectResponse = await tryServeThemeProxy(new Request(
+    `https://monitor.example/?theme-url=${encodeURIComponent(ALLOWED_THEME)}`
+  ));
+  assert(redirectResponse.status === 502, 'theme redirects should be rejected');
+  assert(calls.length === 2, 'allowed theme should reach fetch before redirect rejection');
+
+  const assetResponse = await tryServeThemeProxy(new Request(
+    'https://monitor.example/assets/app.js?v=7',
+    {
+      headers: {
+        Referer: `https://monitor.example/?theme-url=${encodeURIComponent(ALLOWED_THEME)}`,
+        Cookie: 'session=secret'
+      }
+    }
+  ));
+  assert(await assetResponse.text() === 'asset-body', 'asset body should be proxied');
+  assert(calls[2].url === `${ALLOWED_THEME}/assets/app.js?v=7`, 'asset target is incorrect');
+  assert(!assetResponse.headers.get('Set-Cookie'), 'asset cookie should be removed');
+  assert(assetResponse.headers.get('Cache-Control') === 'no-store', 'asset response should not be cached');
+
+  const foreignRefererResponse = await tryServeThemeProxy(new Request(
+    'https://monitor.example/assets/app.js',
+    { headers: { Referer: `https://evil.example/?theme-url=${encodeURIComponent(ALLOWED_THEME)}` } }
+  ));
+  assert(foreignRefererResponse === null, 'cross-origin referer must not activate theme proxy');
+  assert(calls.length === 3, 'cross-origin referer must not reach fetch');
+
+  console.log('Theme proxy tests passed');
+} finally {
+  globalThis.fetch = originalFetch;
+}


### PR DESCRIPTION
## 变更说明

  增加远程主题代理 Demo，允许通过 URL 参数加载指定主题：

  ```text
  /?theme-url=https://huilang-me.github.io/cf-server-monitor-theme-emerald

  ## 主要改动

  - 在原有 / 路由前识别 theme-url 参数并代理主题首页
  - 当前白名单仅允许：
      - https://huilang-me.github.io/cf-server-monitor-theme-emerald

  - 清除主题 HTML 中所有 meta[name="apiBase"]，不依赖 content 的具体内容
  - /assets/* 从同源 Referer 中提取 theme-url 并代理主题资源
  - 非白名单主题返回 403
  - 上游异常或重定向返回 502
  - 使用 redirect: manual，兼容 Cloudflare Workers
  - 不向上游转发 Cookie 和 Authorization
  - 暂不使用缓存，代理响应设置为 Cache-Control: no-store

  ## 安全限制

  - 主题地址必须使用 HTTPS
  - 不允许用户名、密码、查询参数或 Hash
  - 资源路径只能位于白名单主题的 /assets/ 下
  - 仅接受同源 Referer 提供的主题参数
  - 不跟随上游重定向，避免绕过白名单

  ## 验证

  - npm run test:theme-proxy
  - npm run build:frontend
  - wrangler deploy --dry-run
  - 已在独立的 cf-server-monitor-dev Worker 上完成真实主题和资源代理验证