### PR TITLE
fix(deps): update nanoid to 3.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2047,9 +2047,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Update the transitive `nanoid` dependency from `3.3.17` to `3.3.18` in `package-lock.json`.

This fixes [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) / CVE-2026-67213, where `customAlphabet` and `customRandom` can loop indefinitely when called with a size of `0`.

## Scope and impact

- Lockfile-only change; `package.json` is unchanged.
- `nanoid` is a transitive dependency and is not imported directly by the project source.
- No application behavior or public API changes.

## Verification

- [x] `npm ci`
- [x] `npm audit --audit-level=high` — 0 vulnerabilities
- [x] `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- [x] `npm run test:all`
- [x] `npm run build:frontend`
