### PR TITLE
Add daily IP quality and ChatGPT reachability to the monitor

### DIFF
--- a/scripts/IP-QUALITY.md
+++ b/scripts/IP-QUALITY.md
@@ -1,0 +1,63 @@
+# Daily IP quality reports
+
+This extension uses xykt/IPQuality commit
+`3c0eb8856c67ad351020d1edd1bfd4e2515d32fe` (v2026-09-04).
+The installer and collector verify its SHA256 and never auto-update it.
+The script runs IPv4 checks with online report sharing disabled (`-p`).
+
+## Provisioning
+
+1. Apply `scripts/ip-quality-schema.sql` to the Worker's D1 database.
+2. Generate a separate random 32-byte hex token for each server. Store only its
+   SHA256 in `ip_quality_reports.token_hash`, keyed by the existing server ID.
+3. On that server, create `~/.cf-probe/ip-quality/config.json` with mode 600:
+
+   ```json
+   {"url":"https://your-worker.workers.dev","server_id":"SERVER_ID","report_token":"PER_SERVER_TOKEN"}
+   ```
+
+4. Install Python 3, bash, curl, jq, bc, nc, dig and ip. Enable systemd user
+   lingering, then run `sh scripts/install-ip-quality.sh` as the probe user.
+   Keep the collector and the two unit files next to the installer.
+
+Do not put administrator credentials or the main probe API_SECRET in this
+configuration. Configuration files and raw reports must not be committed.
+
+## Operation
+
+The timer runs once daily at 19:15 UTC with up to ten minutes of jitter
+(03:15-03:25 Asia/Shanghai). It catches up after downtime. A run has a ten-minute
+measurement timeout, reduced CPU priority and a 256 MB memory limit.
+
+As the probe user:
+
+```sh
+systemctl --user list-timers cf-ip-quality.timer
+systemctl --user start cf-ip-quality.service
+journalctl --user -u cf-ip-quality.service -n 30
+systemctl --user disable --now cf-ip-quality.timer
+```
+
+The collector keeps `last-check.log`, `last-success.json` and, on upload failure,
+`pending.json` under `~/.cf-probe/ip-quality/`. A later run retries pending data.
+The ordinary `cf-probe` service operates independently.
+
+## Display and validation
+
+The public dashboard and server detail page display the latest successful
+result, masked IPv4, provider scores and flags, and ChatGPT reachability.
+Missing provider data remains unknown. A failed run retains the previous
+successful result; data older than 36 hours is marked stale. Reachability is
+not a guarantee that any particular ChatGPT account or session will work.
+Public reads follow existing site visibility and hidden-server rules.
+
+Run focused tests with Node 24 or newer:
+
+```sh
+node --test test/ip-quality.test.js
+npm run build:frontend
+```
+
+Deploy the D1 table before deploying the Worker routes. Back up this table with
+the main database. When updating from upstream, retain the IP quality routes,
+component imports, collector files and D1 table.

--- a/scripts/cf-ip-quality.service
+++ b/scripts/cf-ip-quality.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Daily IP quality report for CF Server Monitor
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/python3 %h/.cf-probe/ip-quality/collector.py
+WorkingDirectory=%h/.cf-probe/ip-quality
+UMask=0077
+Nice=10
+NoNewPrivileges=yes
+MemoryMax=256M
+TasksMax=128
+CPUQuota=50%
+TimeoutStartSec=15min
+KillMode=control-group

--- a/scripts/cf-ip-quality.timer
+++ b/scripts/cf-ip-quality.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Check IP quality daily at 03:15 China time
+
+[Timer]
+OnCalendar=*-*-* 19:15:00 UTC
+RandomizedDelaySec=600
+Persistent=true
+Unit=cf-ip-quality.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/install-ip-quality.sh
+++ b/scripts/install-ip-quality.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+
+if [ "$(id -u)" -eq 0 ]; then
+  printf '%s\n' 'Run as the non-root probe user, with systemd --user available.' >&2
+  exit 1
+fi
+for command in python3 bash curl jq bc nc dig ip; do
+  command -v "$command" >/dev/null || { printf 'Missing dependency: %s\n' "$command" >&2; exit 1; }
+done
+base=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+destination="$HOME/.cf-probe/ip-quality"
+umask 077
+mkdir -p "$destination" "$HOME/.config/systemd/user"
+test -s "$destination/config.json"
+curl -fL --retry 2 --connect-timeout 10 --max-time 120 \
+  'https://raw.githubusercontent.com/xykt/IPQuality/3c0eb8856c67ad351020d1edd1bfd4e2515d32fe/ip.sh' \
+  -o "$destination/ipquality.sh.new"
+printf 'ffb17dae790341c13023a94c5141775974dd73a3653ca5fba5c4648fc5588402  %s\n' "$destination/ipquality.sh.new" | sha256sum -c -
+mv "$destination/ipquality.sh.new" "$destination/ipquality.sh"
+install -m 700 "$base/ip-quality-collector.py" "$destination/collector.py"
+install -m 600 "$base/cf-ip-quality.service" "$base/cf-ip-quality.timer" "$HOME/.config/systemd/user/"
+systemctl --user daemon-reload
+systemctl --user enable --now cf-ip-quality.timer
+systemctl --user start --no-block cf-ip-quality.service
+systemctl --user list-timers cf-ip-quality.timer --no-pager

--- a/scripts/ip-quality-collector.py
+++ b/scripts/ip-quality-collector.py
@@ -23,6 +23,7 @@ def upload(config, payload):
     url += '/ip-quality/report?id=' + urllib.parse.quote(config['server_id'], safe='')
     request = urllib.request.Request(url, data=json.dumps(payload).encode(), headers={
         'Content-Type': 'application/json',
+        'User-Agent': 'CF-Server-Monitor-IPQuality/1.0',
         'Authorization': 'Bearer ' + config['report_token'],
     })
     for attempt in range(3):
@@ -55,7 +56,9 @@ def collect(directory):
                 os.killpg(process.pid, signal.SIGKILL)
                 process.wait()
                 return {'error': 'timeout'}
-        if code != 0:
+        # The pinned script ends with a disabled IPv6 condition, returning 1
+        # even when its IPv4 JSON report was generated successfully.
+        if code not in (0, 1):
             return {'error': 'check_failed'}
         try:
             report = json.loads(output.read_text())

--- a/scripts/ip-quality-collector.py
+++ b/scripts/ip-quality-collector.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Run the pinned IPQuality release and upload through a per-server token."""
+import hashlib
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+SCRIPT_SHA256 = 'ffb17dae790341c13023a94c5141775974dd73a3653ca5fba5c4648fc5588402'
+
+
+def upload(config, payload):
+    url = config['url'].rstrip('/')
+    if urllib.parse.urlparse(url).scheme != 'https':
+        raise ValueError('HTTPS is required')
+    url += '/ip-quality/report?id=' + urllib.parse.quote(config['server_id'], safe='')
+    request = urllib.request.Request(url, data=json.dumps(payload).encode(), headers={
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + config['report_token'],
+    })
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                result = json.load(response)
+                if result.get('success') is not True:
+                    raise ValueError('Upload was not accepted')
+                return
+        except (urllib.error.URLError, TimeoutError, ValueError):
+            if attempt == 2:
+                raise
+            time.sleep(10)
+
+
+def collect(directory):
+    script = directory / 'ipquality.sh'
+    if hashlib.sha256(script.read_bytes()).hexdigest() != SCRIPT_SHA256:
+        raise ValueError('Pinned script checksum mismatch')
+    with tempfile.TemporaryDirectory(prefix='check-', dir=directory) as temporary:
+        output = Path(temporary) / 'report.json'
+        with (directory / 'last-check.log').open('w') as log:
+            process = subprocess.Popen(
+                ['bash', str(script), '-4', '-E', '-n', '-p', '-f', '-o', str(output)],
+                stdout=log, stderr=log, start_new_session=True,
+            )
+            try:
+                code = process.wait(timeout=600)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait()
+                return {'error': 'timeout'}
+        if code != 0:
+            return {'error': 'check_failed'}
+        try:
+            report = json.loads(output.read_text())
+            if not isinstance(report, dict) or not report.get('Head', {}).get('IP'):
+                raise ValueError('Missing IP')
+        except (OSError, ValueError, AttributeError):
+            return {'error': 'invalid_report'}
+        return {'report': report}
+
+
+def main():
+    os.umask(0o077)
+    directory = Path(__file__).resolve().parent
+    config = json.loads((directory / 'config.json').read_text())
+    pending = directory / 'pending.json'
+    # Retry a completed report before doing another measurement.
+    if pending.exists():
+        previous = json.loads(pending.read_text())
+        if time.time() * 1000 - previous['checked_at'] < 7 * 86400000:
+            try:
+                upload(config, previous)
+                pending.unlink()
+                print('Previous pending report uploaded.', flush=True)
+            except (urllib.error.URLError, TimeoutError, ValueError):
+                print('Previous upload still unavailable; running the scheduled check.', flush=True)
+    try:
+        payload = collect(directory)
+    except (OSError, ValueError):
+        payload = {'error': 'check_failed'}
+    payload['checked_at'] = int(time.time() * 1000)
+    pending.write_text(json.dumps(payload))
+    upload(config, payload)
+    if 'report' in payload:
+        (directory / 'last-success.json').write_text(json.dumps(payload))
+    pending.unlink()
+    print('IP quality result uploaded: ' + ('success' if 'report' in payload else payload['error']), flush=True)
+    return 0 if 'report' in payload else 1
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except Exception as error:
+        print('IP quality collector failed: ' + type(error).__name__, file=sys.stderr)
+        sys.exit(1)

--- a/scripts/ip-quality-schema.sql
+++ b/scripts/ip-quality-schema.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS ip_quality_reports (
+  server_id TEXT PRIMARY KEY,
+  token_hash TEXT NOT NULL,
+  last_attempt INTEGER,
+  last_success INTEGER,
+  ip_fingerprint TEXT,
+  report TEXT,
+  error TEXT
+);

--- a/src/frontend/components/IpQualityPanel.vue
+++ b/src/frontend/components/IpQualityPanel.vue
@@ -1,0 +1,131 @@
+<template>
+  <section class="ip-quality" aria-label="IP 质量">
+    <header class="quality-heading">
+      <h2>IP 质量</h2>
+      <span class="schedule">每日检测</span>
+      <button class="refresh" type="button" :disabled="loading" title="刷新检测结果" aria-label="刷新检测结果" @click="load">↻</button>
+    </header>
+    <p v-if="error" class="quality-error" role="status">结果读取失败，请稍后重试。</p>
+    <p v-if="loading && !reports.length" role="status">加载中...</p>
+    <details v-for="item in reports" :key="item.server_id" :open="Boolean(serverId)" class="quality-server">
+      <summary>
+        <span class="quality-name">{{ item.name }}</span>
+        <span class="quality-status" :class="statusClass(item)">ChatGPT · {{ statusText(item) }}</span>
+        <span class="quality-time">{{ item.last_success ? date(item.last_success) : (item.enabled ? '等待首次检测' : '尚未接入') }}</span>
+      </summary>
+      <div class="quality-content">
+        <p v-if="item.error" class="quality-error">最近检测失败 · {{ date(item.last_attempt) }}<span v-if="item.report">，以下为上次成功结果。</span></p>
+        <p v-else-if="item.stale" class="quality-error">检测结果已超过 36 小时未更新。</p>
+        <p v-if="!item.report" class="empty-state">{{ item.enabled ? '暂无检测结果' : '该服务器尚未安装每日 IP 检测任务' }}</p>
+        <template v-else>
+          <dl class="quality-info">
+            <div><dt>出口 IPv4</dt><dd>{{ item.report.ip }}</dd></div>
+            <div><dt>地区</dt><dd>{{ item.report.info.country || '-' }}</dd></div>
+            <div><dt>ASN</dt><dd>{{ item.report.info.asn ? 'AS' + item.report.info.asn : '-' }}</dd></div>
+            <div><dt>网络运营商</dt><dd>{{ item.report.info.organization || '-' }}</dd></div>
+            <div><dt>ChatGPT 地区</dt><dd>{{ item.report.chatgpt.region || '-' }}</dd></div>
+            <div><dt>IP 归属</dt><dd>{{ typeText(item.report.info.type) }}</dd></div>
+          </dl>
+          <p v-if="item.report.ip_changed" class="quality-error">出口 IP 较上次检测发生变化。</p>
+          <p v-if="item.report.partial" class="partial">部分数据源未返回结果</p>
+          <h3>风险评分</h3>
+          <div class="scores">
+            <div v-for="score in item.report.scores" :key="score.source" class="score">
+              <span>{{ score.source }}</span>
+              <strong>{{ score.value === null ? '无数据' : score.value + score.unit }}</strong>
+            </div>
+          </div>
+          <h3>IP 类型</h3>
+          <div class="quality-table-wrap">
+            <table>
+              <thead><tr><th>数据库</th><th>使用类型</th><th>公司类型</th></tr></thead>
+              <tbody><tr v-for="row in item.report.usage" :key="row.source"><th>{{ row.source }}</th><td>{{ typeText(row.usage) }}</td><td>{{ typeText(row.company) }}</td></tr></tbody>
+            </table>
+          </div>
+          <h3>风险标记</h3>
+          <div class="quality-table-wrap">
+            <table>
+              <thead><tr><th>数据库</th><th v-for="factor in factors" :key="factor.key">{{ factor.label }}</th></tr></thead>
+              <tbody><tr v-for="row in item.report.factors" :key="row.source"><th>{{ row.source }}</th><td v-for="factor in factors" :key="factor.key" :class="{ flagged: row[factor.key] === true }">{{ row[factor.key] === true ? '是' : row[factor.key] === false ? '否' : '-' }}</td></tr></tbody>
+            </table>
+          </div>
+          <footer class="quality-source">IPQuality {{ item.report.version }} · IPv4 · {{ date(item.last_success) }}</footer>
+        </template>
+      </div>
+    </details>
+  </section>
+</template>
+
+<script setup>
+import { ref, watch, onUnmounted } from 'vue'
+import { http } from '../utils/http'
+import { getApiBases } from '../utils/config'
+
+const props = defineProps({ serverId: { type: String, default: '' }, apiIndex: { type: Number, default: 0 } })
+const reports = ref([])
+const loading = ref(false)
+const error = ref(false)
+let generation = 0
+const factors = [
+  { key: 'Proxy', label: '代理' }, { key: 'VPN', label: 'VPN' }, { key: 'Tor', label: 'Tor' },
+  { key: 'Server', label: '机房' }, { key: 'Abuser', label: '滥用' }, { key: 'Robot', label: '机器人' }
+]
+const labels = { available: '可达', blocked: '受限', web_only: '仅网页', app_only: '仅 App', unknown: '未知' }
+const date = value => new Date(value).toLocaleString('zh-CN', { hour12: false })
+const statusText = item => item.error ? '检测失败' : item.stale ? '结果过期' : labels[item.report?.chatgpt.status] || '待检测'
+const statusClass = item => !item.error && !item.stale && item.report?.chatgpt.status === 'available' ? 'available' : 'uncertain'
+const typeText = value => ({ ISP: '家宽 / ISP', 'Line ISP': '家宽 / ISP', Hosting: '机房', 'Data Center': '机房', Business: '商业', 'Geo-consistent': '原生 IP', Native: '原生', Broadcast: '广播 IP' })[value] || value || '-'
+async function load() {
+  const current = ++generation
+  loading.value = true
+  const result = await http.get('/api/ip-quality' + (props.serverId ? '?id=' + encodeURIComponent(props.serverId) : ''), {
+    baseUrl: getApiBases()[props.apiIndex], autoRedirect: false
+  })
+  if (current !== generation) return
+  error.value = Boolean(result.error)
+  if (!result.error) reports.value = result.data?.reports || []
+  loading.value = false
+}
+watch(() => [props.serverId, props.apiIndex], () => { reports.value = []; load() }, { immediate: true })
+const timer = setInterval(load, 300000)
+onUnmounted(() => { clearInterval(timer); generation++ })
+</script>
+
+<style scoped>
+.ip-quality { margin: 24px 0; border-top: 1px solid var(--border-color, #d3d7d4); padding-top: 18px; color: var(--text-primary); letter-spacing: 0; }
+.quality-heading { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
+h2 { margin: 0; font-size: 18px; }
+h3 { margin: 20px 0 10px; font-size: 14px; }
+.schedule, .quality-time, dt, .score > span, .quality-source, .partial { color: var(--text-muted, #717871); font-size: 12px; }
+.refresh { margin-left: auto; width: 32px; height: 32px; border: 1px solid var(--border-color, #d3d7d4); border-radius: 4px; background: transparent; color: inherit; font-size: 22px; cursor: pointer; }
+.refresh:disabled { opacity: .5; cursor: wait; }
+.quality-server { border-bottom: 1px solid var(--border-color, #d3d7d4); }
+summary { cursor: pointer; display: flex; flex-wrap: wrap; align-items: center; gap: 10px 16px; padding: 14px 0; list-style: none; }
+summary::before { content: '+'; width: 12px; flex-shrink: 0; }
+details[open] > summary::before { content: '-'; }
+.quality-name { font-weight: 600; overflow-wrap: anywhere; }
+.quality-status { font-size: 12px; }
+.available { color: var(--accent-color, #287c62); }
+.uncertain, .partial { color: #a77527; }
+.quality-time { margin-left: auto; }
+.quality-content { padding: 0 0 16px; }
+.quality-info { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px 24px; padding: 12px 0; margin: 0; }
+dd { margin: 5px 0 0; font-size: 13px; overflow-wrap: anywhere; }
+.scores { display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); border-bottom: 1px solid var(--border-color, #d3d7d4); }
+.score { display: flex; flex-direction: column; gap: 8px; padding: 8px 8px 14px 0; min-width: 0; overflow-wrap: anywhere; }
+.score strong { font-size: 19px; font-weight: 500; }
+.quality-table-wrap { overflow-x: auto; }
+table { border-collapse: collapse; width: 100%; font-size: 12px; }
+th, td { padding: 9px 12px; text-align: left; border-bottom: 1px solid var(--border-color, #d3d7d4); white-space: nowrap; }
+th { font-weight: 500; }
+.flagged, .quality-error { color: #c04e4e; }
+.quality-error, .empty-state { font-size: 13px; }
+.quality-source { margin-top: 16px; }
+@media (max-width: 640px) {
+  .quality-info { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .scores { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .quality-time { width: 100%; margin-left: 28px; }
+  .quality-status { margin-left: auto; }
+  th, td { padding: 8px; }
+}
+</style>

--- a/src/frontend/views/Dashboard.vue
+++ b/src/frontend/views/Dashboard.vue
@@ -359,6 +359,7 @@
       @continue="continueLiveConnection"
     />
 
+    <IpQualityPanel v-if="!isLoading" />
     <Footer />
   </div>
 </template>
@@ -367,6 +368,7 @@
 import { ref, computed, inject, nextTick, onMounted, onUnmounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import TerminalHeader from '../components/TerminalHeader.vue'
+import IpQualityPanel from '../components/IpQualityPanel.vue'
 import ServerBarCard from '../components/ServerBarCard.vue'
 import ServerRingCard from '../components/ServerRingCard.vue'
 import Footer from '../components/Footer.vue'

--- a/src/frontend/views/ServerDetail.vue
+++ b/src/frontend/views/ServerDetail.vue
@@ -111,6 +111,8 @@
       </div>
     </div>
 
+    <IpQualityPanel :server-id="serverId" :api-index="apiIndex" />
+
     <div class="charts-container">
       <div class="chart-card" :class="{ 'full-width': isChartExpanded('cpu') }">
         <div class="chart-card-header">
@@ -352,6 +354,7 @@
 import { ref, computed, inject, onMounted, onUnmounted, watch, nextTick, h } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import TerminalHeader from '../components/TerminalHeader.vue'
+import IpQualityPanel from '../components/IpQualityPanel.vue'
 import Footer from '../components/Footer.vue'
 import OsIcon from '../components/OsIcon.vue'
 import LiveConnectionTimeoutModal from '../components/LiveConnectionTimeoutModal.vue'

--- a/src/handlers/ipQuality.js
+++ b/src/handlers/ipQuality.js
@@ -1,0 +1,112 @@
+import { checkAuth } from '../middleware/auth.js';
+import { createSuccessResponse, createBadRequestResponse, createUnauthorizedResponse, createNotFoundResponse } from '../utils/errors.js';
+
+const SOURCES = ['IP2LOCATION', 'SCAMALYTICS', 'ipapi', 'AbuseIPDB', 'IPQS', 'DBIP'];
+const FACTOR_SOURCES = ['IP2LOCATION', 'ipapi', 'ipregistry', 'IPQS', 'SCAMALYTICS', 'ipdata', 'IPinfo', 'DBIP'];
+const FACTORS = ['Proxy', 'Tor', 'VPN', 'Server', 'Abuser', 'Robot'];
+const ID = /^[a-zA-Z0-9_.:-]{1,64}$/;
+const text = (value, limit = 120) => typeof value === 'string' && value.trim().toLowerCase() !== 'null'
+  ? value.trim().replace(/[\x00-\x1f\x7f]/g, '').slice(0, limit) : '';
+
+export async function digest(value) {
+  const bytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(bytes), b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export function normalizeReport(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) throw new Error('Invalid report');
+  const ip = text(raw.Head?.IP, 45);
+  const parts = ip.split('.');
+  if (parts.length !== 4 || parts.some(p => !/^\d{1,3}$/.test(p) || Number(p) > 255)) throw new Error('Invalid IPv4 report');
+  const scores = SOURCES.map(source => {
+    const input = raw.Score?.[source];
+    const cleaned = typeof input === 'number' ? String(input) : text(input, 20);
+    const value = /^\d+(\.\d+)?%?$/.test(cleaned) ? Number(cleaned.replace('%', '')) : null;
+    return { source, value: value !== null && value <= 100 ? value : null, unit: cleaned.endsWith('%') ? '%' : '' };
+  });
+  const status = text(raw.Media?.ChatGPT?.Status, 30);
+  const chatgptStatus = ({ Yes: 'available', Block: 'blocked', WebOnly: 'web_only', APPOnly: 'app_only' })[status] || 'unknown';
+  const info = {
+    asn: text(raw.Info?.ASN, 20), organization: text(raw.Info?.Organization),
+    country: text(raw.Info?.Region?.Code, 8), type: text(raw.Info?.Type, 40)
+  };
+  if (!info.asn && scores.every(s => s.value === null) && chatgptStatus === 'unknown') throw new Error('Report contains no usable measurements');
+  return {
+    ip,
+    data: {
+      ip: `${parts[0]}.${parts[1]}.*.*`, version: text(raw.Head?.Version, 40), info, scores,
+      chatgpt: { status: chatgptStatus, region: text(raw.Media?.ChatGPT?.Region, 8), type: text(raw.Media?.ChatGPT?.Type, 30) },
+      usage: ['IPinfo', 'ipregistry', 'ipapi', 'AbuseIPDB', 'IP2LOCATION'].map(source => ({
+        source, usage: text(raw.Type?.Usage?.[source], 40), company: text(raw.Type?.Company?.[source], 40)
+      })),
+      factors: FACTOR_SOURCES.map(source => ({ source, ...Object.fromEntries(FACTORS.map(factor => {
+        const value = raw.Factor?.[factor]?.[source];
+        return [factor, typeof value === 'boolean' ? value : null];
+      })) })),
+      partial: scores.some(s => s.value === null) || chatgptStatus === 'unknown'
+    }
+  };
+}
+
+async function readBoundedJson(request) {
+  const reader = request.body?.getReader();
+  if (!reader) throw new Error('Empty request');
+  let total = 0;
+  const chunks = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > 32768) { await reader.cancel(); throw new Error('Report too large'); }
+    chunks.push(value);
+  }
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) { body.set(chunk, offset); offset += chunk.byteLength; }
+  return JSON.parse(new TextDecoder().decode(body));
+}
+
+export async function handleIpQualityReport(request, env) {
+  const id = new URL(request.url).searchParams.get('id') || '';
+  const token = (request.headers.get('Authorization') || '').replace(/^Bearer /, '');
+  if (!ID.test(id) || !/^[a-f0-9]{64}$/.test(token)) return createUnauthorizedResponse();
+  const row = await env.DB.prepare('SELECT q.* FROM ip_quality_reports q JOIN servers s ON s.id=q.server_id WHERE q.server_id=?').bind(id).first();
+  if (!row || await digest(token) !== row.token_hash) return createUnauthorizedResponse();
+  let body;
+  try { body = await readBoundedJson(request); } catch { return createBadRequestResponse('Invalid report JSON'); }
+  const checkedAt = body?.checked_at;
+  const now = Date.now();
+  if (!Number.isSafeInteger(checkedAt) || checkedAt > now + 300000 || checkedAt < now - 7 * 86400000) return createBadRequestResponse('Invalid report time');
+  if (row.last_attempt && checkedAt <= row.last_attempt) return createSuccessResponse({ success: true, duplicate: true });
+  if (body.error) {
+    const error = ['timeout', 'invalid_report', 'check_failed'].includes(body.error) ? body.error : 'check_failed';
+    await env.DB.prepare('UPDATE ip_quality_reports SET last_attempt=?, error=? WHERE server_id=? AND (last_attempt IS NULL OR last_attempt<?)')
+      .bind(checkedAt, error, id, checkedAt).run();
+    return createSuccessResponse({ success: true });
+  }
+  let report;
+  try { report = normalizeReport(body.report); } catch { return createBadRequestResponse('Invalid IP quality report'); }
+  const fingerprint = await digest(report.ip);
+  report.data.ip_changed = Boolean(row.ip_fingerprint && fingerprint !== row.ip_fingerprint);
+  await env.DB.prepare('UPDATE ip_quality_reports SET last_attempt=?, last_success=?, ip_fingerprint=?, report=?, error=NULL WHERE server_id=? AND (last_attempt IS NULL OR last_attempt<?)')
+    .bind(checkedAt, checkedAt, fingerprint, JSON.stringify(report.data), id, checkedAt).run();
+  return createSuccessResponse({ success: true });
+}
+
+export async function handleIpQualityRead(request, env, sys) {
+  const admin = await checkAuth(request, env, sys);
+  if (sys?.is_public !== 'true' && !admin) return createUnauthorizedResponse();
+  const id = new URL(request.url).searchParams.get('id');
+  if (id && !ID.test(id)) return createBadRequestResponse('Invalid server id');
+  const result = await env.DB.prepare(`SELECT s.id, s.name, s.is_hidden, q.server_id, q.last_attempt, q.last_success, q.report, q.error
+    FROM servers s LEFT JOIN ip_quality_reports q ON q.server_id=s.id ${id ? 'WHERE s.id=?' : ''} ORDER BY s.sort_order ASC`)
+    .bind(...(id ? [id] : [])).all();
+  const visible = result.results.filter(row => admin || (row.is_hidden !== '1' && row.is_hidden !== 1));
+  if (id && !visible.length) return createNotFoundResponse();
+  return createSuccessResponse({ reports: visible.map(row => ({
+    server_id: row.id, name: row.name, enabled: Boolean(row.server_id),
+    last_attempt: row.last_attempt, last_success: row.last_success, error: row.error,
+    stale: Boolean(row.last_success && Date.now() - row.last_success > 36 * 3600000),
+    report: row.report ? JSON.parse(row.report) : null
+  })) }, { 'Cache-Control': 'no-store' });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { handleAdminAPI } from './handlers/admin.js';
 import { serveFrontend } from './handlers/frontend.js';
 import { handleUpdate, handleWebSocketUpgrade, handleUpdateWebSocketUpgrade } from './handlers/update.js';
 import { handleServerAPI, handleServersAPI } from './handlers/dashboard.js';
+import { handleIpQualityRead, handleIpQualityReport } from './handlers/ipQuality.js';
 import { handleTheme } from './handlers/theme.js';
 import { isValidThemeOptions, loadSettings, loadSiteSettings, loadAppearanceOptions, normalizeFrontendWsTimeoutMinutes, normalizeLongHistoryPoints, saveThemeOptions, setDebug, debug } from './utils/settings.js';
 import { checkAuth, simpleAuthResponse } from './middleware/auth.js';
@@ -261,6 +262,11 @@ export default {
     }
 
     const routes = [
+      { method: 'POST', path: '/ip-quality/report', handler: () => handleIpQualityReport(request, env) },
+      { method: 'GET', path: '/api/ip-quality', handler: async () => {
+        await ensureSiteSettings();
+        return handleIpQualityRead(request, env, sys);
+      }},
       { method: 'POST', path: '/update', handler: () => handleUpdate(request, env, ctx) },
       { method: 'GET', path: '/update', handler: () => handleUpdateWebSocketUpgrade(request, env) },
       { method: 'GET', path: '/__do/health', handler: async () => {

--- a/test/ip-quality.test.js
+++ b/test/ip-quality.test.js
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+import { readFileSync } from 'node:fs';
+import { digest, normalizeReport, handleIpQualityRead, handleIpQualityReport } from '../src/handlers/ipQuality.js';
+
+const token = 'a'.repeat(64);
+const fixture = () => ({
+  Head: { IP: '203.0.113.42', Version: 'v2026-09-04' },
+  Info: { ASN: '64500', Organization: 'Example ISP', Region: { Code: 'US' }, Type: 'Geo-consistent' },
+  Score: { IP2LOCATION: '3', SCAMALYTICS: '0', ipapi: '0.32%', IPQS: '75', AbuseIPDB: 'null', DBIP: '-1' },
+  Factor: { Proxy: { IPQS: true, ipapi: false }, VPN: { IPQS: true } },
+  Media: { ChatGPT: { Status: 'Yes', Region: 'US', Type: 'Native' } },
+  private_key: 'must-not-leak'
+});
+async function setup() {
+  const sqlite = new DatabaseSync(':memory:');
+  sqlite.exec('CREATE TABLE servers (id TEXT PRIMARY KEY, name TEXT, is_hidden TEXT, sort_order INTEGER)');
+  sqlite.exec("INSERT INTO servers VALUES ('one','CloudLead-US','0',0),('hidden','Hidden','1',1),('other','Other','0',2)");
+  sqlite.exec(readFileSync(new URL('../scripts/ip-quality-schema.sql', import.meta.url), 'utf8'));
+  sqlite.prepare('INSERT INTO ip_quality_reports(server_id,token_hash) VALUES (?,?)').run('one', await digest(token));
+  const DB = { prepare(sql) { return { bind(...args) { const query = sqlite.prepare(sql); return {
+    first: async () => query.get(...args) || null,
+    all: async () => ({ results: query.all(...args) }),
+    run: async () => query.run(...args)
+  }; } }; } };
+  return { env: { DB }, sqlite };
+}
+function post(data, credential = token, id = 'one') {
+  return new Request(`https://monitor.test/ip-quality/report?id=${id}`, {
+    method: 'POST', headers: { Authorization: `Bearer ${credential}` }, body: JSON.stringify(data)
+  });
+}
+
+test('normalizes scores without inventing missing values; masks IP and allowlists report fields', () => {
+  const result = normalizeReport(fixture()).data;
+  assert.equal(result.ip, '203.0.*.*');
+  assert.equal(result.chatgpt.status, 'available');
+  assert.deepEqual(result.scores.find(s => s.source === 'ipapi'), { source: 'ipapi', value: 0.32, unit: '%' });
+  assert.equal(result.scores.find(s => s.source === 'AbuseIPDB').value, null);
+  assert.equal(result.scores.find(s => s.source === 'DBIP').value, null);
+  assert.equal(result.factors.find(s => s.source === 'ipapi').Proxy, false);
+  assert.equal(result.factors.find(s => s.source === 'IPinfo').Proxy, null);
+  assert.equal(result.partial, true);
+  assert.ok(!JSON.stringify(result).includes('must-not-leak'));
+  assert.throws(() => normalizeReport({ Head: { IP: '203.0.113.256' } }));
+  assert.throws(() => normalizeReport({ Head: { IP: '203.0.113.2' } }));
+});
+
+test('report token is scoped to one registered server and invalid reports cannot overwrite data', async () => {
+  const { env, sqlite } = await setup();
+  const time = Date.now() - 1000;
+  const data = { checked_at: time, report: fixture() };
+  assert.equal((await handleIpQualityReport(post(data, 'b'.repeat(64)), env)).status, 401);
+  assert.equal((await handleIpQualityReport(post(data, token, 'other'), env)).status, 401);
+  assert.equal((await handleIpQualityReport(post(data), env)).status, 200);
+  assert.equal((await handleIpQualityReport(post({ checked_at: time + 1, report: { Head: { IP: 'bad' } } }), env)).status, 400);
+  assert.equal((await handleIpQualityReport(post({ ...data, padding: 'x'.repeat(33000) }), env)).status, 400);
+  assert.equal(sqlite.prepare('SELECT last_success FROM ip_quality_reports').get().last_success, time);
+  sqlite.close();
+});
+
+test('failure retains last success, late reports cannot roll back state, IP changes are detected', async () => {
+  const { env, sqlite } = await setup();
+  const time = Date.now() - 10000;
+  await handleIpQualityReport(post({ checked_at: time, report: fixture() }), env);
+  await handleIpQualityReport(post({ checked_at: time + 1000, error: 'timeout' }), env);
+  let row = sqlite.prepare('SELECT * FROM ip_quality_reports').get();
+  assert.equal(row.last_success, time);
+  assert.equal(row.error, 'timeout');
+  assert.ok(row.report);
+  await handleIpQualityReport(post({ checked_at: time, report: fixture() }), env);
+  assert.equal(sqlite.prepare('SELECT error FROM ip_quality_reports').get().error, 'timeout');
+  const next = fixture(); next.Head.IP = '203.0.113.43';
+  await handleIpQualityReport(post({ checked_at: time + 2000, report: next }), env);
+  row = sqlite.prepare('SELECT * FROM ip_quality_reports').get();
+  assert.equal(row.error, null);
+  assert.equal(JSON.parse(row.report).ip_changed, true);
+  assert.ok(!row.report.includes('203.0.113.43'));
+  sqlite.close();
+});
+
+test('public read respects private mode and hidden servers without exposing upload credentials', async () => {
+  const { env, sqlite } = await setup();
+  const request = new Request('https://monitor.test/api/ip-quality');
+  assert.equal((await handleIpQualityRead(request, env, { is_public: 'false' })).status, 401);
+  const response = await handleIpQualityRead(request, env, { is_public: 'true' });
+  const body = await response.json();
+  assert.deepEqual(body.reports.map(r => r.name), ['CloudLead-US', 'Other']);
+  assert.equal(body.reports[1].enabled, false);
+  assert.ok(!JSON.stringify(body).includes('token_hash'));
+  assert.equal((await handleIpQualityRead(new Request('https://monitor.test/api/ip-quality?id=hidden'), env, { is_public: 'true' })).status, 404);
+  sqlite.close();
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -20,6 +20,7 @@ binding = "ASSETS"
 [[d1_databases]]
 binding = "DB"
 database_name = "server-monitor-db"
+database_id = "10ddcccb-4b53-44ec-929b-c3c672439261"
 
 # Durable Objects：实时指标广播中心
 # 注意：首次部署前需要执行 `wrangler durable-object create MetricsBroadcaster --class MetricsBroadcaster`


### PR DESCRIPTION
Add per-server daily IPv4 checks and display provider scores, risk flags, IP classification and ChatGPT reachability on the public dashboard and server details. Uploads use individual hashed tokens; public results mask the IP and retain the last successful report after failures.

Validated: 4 focused API tests, frontend production build, live CloudLead-US collection and upload, anonymous write rejection, public dashboard data and existing probe health. 36 existing tests passed; one existing Vite socket test was blocked by the local macOS development-certificate trust prompt.

The D1 schema is provisioned. CloudLead-US runs daily at 03:15-03:25 Asia/Shanghai. CStone is not enrolled.